### PR TITLE
feat: login layout

### DIFF
--- a/src/common/components/Auth/AuthCard.tsx
+++ b/src/common/components/Auth/AuthCard.tsx
@@ -1,10 +1,4 @@
-import {
-  forwardRef,
-  type ComponentProps,
-  type ElementType,
-  type ReactNode,
-  type Ref,
-} from "react";
+import { type ComponentProps, type ElementType, type ReactNode } from "react";
 
 type AuthCardProps<T extends ElementType = ElementType> = {
   as?: T;
@@ -17,24 +11,21 @@ const defaultElement = "h1";
 type TitleProps<T extends ElementType> = AuthCardProps<T> &
   Omit<ComponentProps<T>, keyof AuthCardProps<T>>;
 
-export const AuthCard = forwardRef(
-  <T extends ElementType = typeof defaultElement>(
-    { children, title = "Login", as, ...rest }: TitleProps<T>,
-    ref: Ref<HTMLDivElement>
-  ) => {
-    const Title = as || defaultElement;
-    return (
-      <div
-        ref={ref}
-        className="mt-10 flex w-96 min-w-fit flex-col gap-y-5 rounded-lg bg-bg-alt px-4 py-5"
-      >
-        <Title className="text-lg font-bold text-text-em-high" {...rest}>
-          {title}
-        </Title>
-        <div>{children}</div>
-      </div>
-    );
-  }
-);
+export const AuthCard = <T extends ElementType = typeof defaultElement>({
+  children,
+  title = "Login",
+  as,
+  ...rest
+}: TitleProps<T>) => {
+  const Title = as || defaultElement;
+  return (
+    <div className="mt-10 flex w-96 min-w-fit flex-col gap-y-5 rounded-lg bg-bg-alt px-4 py-5">
+      <Title className="text-lg font-bold text-text-em-high" {...rest}>
+        {title}
+      </Title>
+      <div>{children}</div>
+    </div>
+  );
+};
 
 AuthCard.displayName = "AuthCard";

--- a/src/common/components/Auth/AuthCard.tsx
+++ b/src/common/components/Auth/AuthCard.tsx
@@ -1,18 +1,40 @@
-import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import {
+  forwardRef,
+  type ComponentProps,
+  type ElementType,
+  type ReactNode,
+  type Ref,
+} from "react";
 
-export const AuthCard = forwardRef<
-  HTMLDivElement,
-  ComponentPropsWithoutRef<"div">
->(({ children, title = "Login" }, ref) => {
-  return (
-    <div
-      ref={ref}
-      className="mt-10 flex w-96 min-w-fit flex-col gap-y-5 rounded-lg bg-bg-alt px-4 py-5"
-    >
-      <div className="text-lg font-bold text-text-em-high">{title}</div>
-      <div>{children}</div>
-    </div>
-  );
-});
+type AuthCardProps<T extends ElementType = ElementType> = {
+  as?: T;
+  title?: string;
+  children?: ReactNode;
+};
+
+const defaultElement = "h1";
+
+type TitleProps<T extends ElementType> = AuthCardProps<T> &
+  Omit<ComponentProps<T>, keyof AuthCardProps<T>>;
+
+export const AuthCard = forwardRef(
+  <T extends ElementType = typeof defaultElement>(
+    { children, title = "Login", as, ...rest }: TitleProps<T>,
+    ref: Ref<HTMLDivElement>
+  ) => {
+    const Title = as || defaultElement;
+    return (
+      <div
+        ref={ref}
+        className="mt-10 flex w-96 min-w-fit flex-col gap-y-5 rounded-lg bg-bg-alt px-4 py-5"
+      >
+        <Title className="text-lg font-bold text-text-em-high" {...rest}>
+          {title}
+        </Title>
+        <div>{children}</div>
+      </div>
+    );
+  }
+);
 
 AuthCard.displayName = "AuthCard";

--- a/src/common/components/Auth/AuthCard.tsx
+++ b/src/common/components/Auth/AuthCard.tsx
@@ -1,0 +1,18 @@
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+
+export const AuthCard = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div">
+>(({ children, title = "Login" }, ref) => {
+  return (
+    <div
+      ref={ref}
+      className="mt-10 flex w-96 min-w-fit flex-col gap-y-5 rounded-lg bg-bg-alt px-4 py-5"
+    >
+      <div className="text-lg font-bold text-text-em-high">{title}</div>
+      <div>{children}</div>
+    </div>
+  );
+});
+
+AuthCard.displayName = "AuthCard";

--- a/src/common/components/Auth/index.ts
+++ b/src/common/components/Auth/index.ts
@@ -1,0 +1,1 @@
+export * from "./AuthCard";

--- a/src/common/components/CoreLayout/CoreLayout.tsx
+++ b/src/common/components/CoreLayout/CoreLayout.tsx
@@ -1,7 +1,15 @@
 import { type PropsWithChildren } from "react";
+import { Sidebar } from "./Sidebar";
 
-interface Props extends PropsWithChildren {}
+type Props = PropsWithChildren;
 
 export const CoreLayout = ({ children }: Props) => {
-  return <div className="relative h-full min-h-full">{children}</div>;
+  return (
+    <div className="relative flex h-full min-h-full flex-auto">
+      <aside>
+        <Sidebar />
+      </aside>
+      <main className="grow">{children}</main>
+    </div>
+  );
 };

--- a/src/common/components/CoreLayout/Sidebar.tsx
+++ b/src/common/components/CoreLayout/Sidebar.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export const Sidebar = () => {
+  return <div className="h-full border">Sidebar</div>;
+};

--- a/src/common/components/CoreLayout/index.ts
+++ b/src/common/components/CoreLayout/index.ts
@@ -1,1 +1,2 @@
 export * from "./CoreLayout";
+export * from "./Sidebar";

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,13 @@
+import { PageHead } from "@/common/components/PageHead";
+import { AuthCard } from "@/common/components/Auth";
+
+export default function Home() {
+  return (
+    <>
+      <PageHead name="AfterClass" />
+      <section className="flex h-full flex-col items-center space-y-6 p-6">
+        <AuthCard></AuthCard>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
This PR is for #8 
<img width="503" alt="SCR-20230910-svds" src="https://github.com/AfterClass-io/afterclass.io-v2/assets/68373112/88a53f88-6c22-4db9-8168-f179d31a1f28">

## Implementation
- CoreLayout
   - created a pseudo `Sidebar` component in `/CoreLayout`
   - added the `Sidebar` component to `CoreLayout.tsx`

- AuthCard
   - created `AuthCard` component which allows changing of the card title through `title` prop. (default value has been set to 'Login') 
   - allow overriding of card props using `forwardRef`

## Note
- input component left out
- button component left out
- sidebar content left for another issue