### PR TITLE
feat: input component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,34 @@
+{
+  // eslint extension options
+  "eslint.enable": true,
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  // prettier extension setting
+  "editor.formatOnSave": true,
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.rulers": [80],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  // Show in vscode "Problems" tab when there are errors
+  "typescript.tsserver.experimental.enableProjectDiagnostics": true,
+  // For tailwind-variants
+  "tailwindCSS.experimental.classRegex": [
+    ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^18.2.0",
     "sass": "^1.66.1",
     "superjson": "1.12.2",
+    "tailwind-variants": "^0.1.14",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/src/common/components/Input/Input.theme.ts
+++ b/src/common/components/Input/Input.theme.ts
@@ -1,0 +1,38 @@
+import { type VariantProps, tv } from "tailwind-variants";
+
+export type InputVariants = VariantProps<typeof inputTheme>;
+
+export const inputTheme = tv(
+  {
+    slots: {
+      wrapper: [
+        "bg-surface-base",
+        "border",
+        "border-border-default",
+        "rounded-lg",
+        "flex",
+        "items-center",
+        "focus-ring",
+      ],
+      input: [
+        "bg-transparent",
+        "outline-none",
+        "placeholder:text-text-em-low",
+        "flex-1",
+      ],
+    },
+    variants: {
+      size: {
+        md: {
+          wrapper: ["h-[44px]", "px-3", "gap-2.5"],
+          input: ["text-base"],
+        },
+        sm: {
+          wrapper: ["h-8", "px-2", "gap-1.5"],
+          input: ["text-sm"],
+        },
+      },
+    },
+  },
+  { responsiveVariants: true }
+);

--- a/src/common/components/Input/Input.tsx
+++ b/src/common/components/Input/Input.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode, type ComponentPropsWithoutRef } from "react";
+import { type InputVariants, inputTheme } from "./Input.theme";
+
+export type InputProps = Omit<ComponentPropsWithoutRef<"input">, "size"> &
+  InputVariants & {
+    leftContent?: ReactNode;
+    rightContent?: ReactNode;
+    wrapperProps?: ComponentPropsWithoutRef<"div">;
+  };
+
+export const Input = ({
+  className,
+  size = "md",
+  leftContent,
+  rightContent,
+  wrapperProps,
+  ...props
+}: InputProps) => {
+  const { input: inputClasses, wrapper } = inputTheme({ className, size });
+  return (
+    <div
+      {...wrapperProps}
+      className={wrapper({ className: wrapperProps?.className })}
+    >
+      {leftContent}
+      <input {...props} className={inputClasses({ className })} />
+      {rightContent}
+    </div>
+  );
+};

--- a/src/common/components/Input/index.ts
+++ b/src/common/components/Input/index.ts
@@ -1,0 +1,1 @@
+export * from "./Input";

--- a/src/common/styles/components.scss
+++ b/src/common/styles/components.scss
@@ -1,0 +1,5 @@
+@layer components {
+  .focus-ring {
+    @apply focus-within:border-primary-default focus-within:ring-2 focus-within:ring-primary-default/20;
+  }
+}

--- a/src/common/styles/globals.scss
+++ b/src/common/styles/globals.scss
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "./components.scss";
+
 @layer base {
   html {
     font-size: 16px;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useCallback } from "react";
 import { PageHead } from "@/common/components/PageHead";
 import { Icon } from "@iconify-icon/react";
 import { StarLineAltIcon } from "@/common/components/CustomIcon";
+import { Input } from "@/common/components/Input";
 
 export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
@@ -45,6 +46,19 @@ export default function Home() {
             {hello.data ? hello.data.greeting : "Loading tRPC query..."}
           </span>
           <AuthShowcase />
+        </div>
+        <div className="space-y-4">
+          <Input
+            leftContent={<StarLineAltIcon />}
+            rightContent={<StarLineAltIcon />}
+            placeholder="Write here"
+          />
+          <Input
+            leftContent={<StarLineAltIcon size={16} />}
+            rightContent={<StarLineAltIcon size={16} />}
+            placeholder="Write here"
+            size={{ initial: "sm", md: "md" }}
+          />
         </div>
       </section>
     </>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,8 +3,10 @@ import { themingSystemPlugin } from "./src/common/tools/tailwind/plugins/theming
 import { fontFamily } from "tailwindcss/defaultTheme";
 
 import { type Config } from "tailwindcss";
+import { withTV } from "tailwind-variants/dist/transformer";
 
-export default {
+// withTv is required for tailwind-variants resposnive variants to work
+export default withTV({
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
@@ -15,4 +17,4 @@ export default {
     },
   },
   plugins: [themingSystemPlugin],
-} satisfies Config;
+}) satisfies Config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,16 +1623,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-human-signals@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
-  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-
-human-signals@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
-  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
-
 iconify-icon@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/iconify-icon/-/iconify-icon-1.0.8.tgz#ad7a36731dca0da0204e488ef0b9ebdad2a7d760"
@@ -2739,6 +2729,18 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+tailwind-merge@^1.13.2:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.14.0.tgz#e677f55d864edc6794562c63f5001f45093cdb8b"
+  integrity sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==
+
+tailwind-variants@^0.1.14:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/tailwind-variants/-/tailwind-variants-0.1.14.tgz#1c9d59b92f5c902e8157ee14256eb4b90d287963"
+  integrity sha512-qfOkSGP+cSolTTkJboldGmiM+w5uE77pazCRkwixEBsuaml9CmhN0E8qgH7QnZNmOTVSsgRK1tn/MsKOvOKVWA==
+  dependencies:
+    tailwind-merge "^1.13.2"
 
 tailwindcss@^3.3.0:
   version "3.3.3"


### PR DESCRIPTION
### Changes
- Import `tailwind-variants` library for managing tailwind classes and component states
- Create `Input` component matching figma design
- Includes example on index page
- Added vscode preferences

### Preview

https://github.com/AfterClass-io/afterclass.io-v2/assets/6003064/4209fc36-6c9a-4455-82d6-173a8a2ec72c

#### Light mode

![CleanShot 2023-10-03 at 00 48 58@2x](https://github.com/AfterClass-io/afterclass.io-v2/assets/6003064/5cf8895d-4994-4c0d-a304-b3749a48b735)
