### PR TITLE
feat: button component

### DIFF
--- a/src/common/components/Button/Button.theme.ts
+++ b/src/common/components/Button/Button.theme.ts
@@ -1,0 +1,129 @@
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const buttonIconTheme = tv(
+  {
+    variants: {
+      variant: {
+        primary: ["text-text-on-primary"],
+        secondary: ["text-text-on-secondary"],
+        tertiary: ["text-text-on-tertiary"],
+        success: ["text-text-on-primary"],
+        danger: ["text-text-on-primary"],
+      },
+      size: {
+        sm: ["h-3", "w-3"],
+        md: ["h-4", "w-4"],
+      },
+    },
+  },
+  { responsiveVariants: true }
+);
+
+export const buttonTheme = tv(
+  {
+    base: [
+      "relative",
+      "flex",
+      "w-fit",
+      "leading-none",
+      "text-center",
+      "justify-center",
+      "items-center",
+      "font-semibold",
+      "focus-ring",
+      "transition-all",
+      "duration-300",
+      "after:inset-0",
+      "after:absolute",
+      "focus:outline-none",
+      "hover:after:bg-white/10",
+      "active:after:bg-transparent",
+      "border",
+      "border-transparent",
+      "data-[disabled]:border-transparent",
+      "data-[disabled]:after:bg-transparent",
+      "data-[disabled]:text-text-placeholder",
+      "disabled:border-transparent",
+      "disabled:after:bg-transparent",
+      "disabled:text-text-placeholder",
+    ],
+    variants: {
+      variant: {
+        primary: [
+          "bg-primary-default",
+          "border-border-primary",
+          "text-text-on-primary",
+          "disabled:bg-element-disabled",
+          "data-[disabled]:bg-element-disabled",
+        ],
+        secondary: [
+          "bg-element-secondary",
+          "border-border-secondary",
+          "text-text-on-secondary",
+          "disabled:bg-element-disabled",
+          "data-[disabled]:bg-element-disabled",
+        ],
+        tertiary: [
+          "bg-element-tertiary",
+          "border-border-default",
+          "text-text-on-tertiary",
+          "disabled:bg-element-disabled",
+          "data-[disabled]:bg-element-disabled",
+        ],
+        success: [
+          "bg-green-600",
+          "text-text-on-primary",
+          "disabled:bg-element-disabled",
+          "data-[disabled]:bg-element-disabled",
+        ],
+        danger: [
+          "bg-red-600",
+          "text-text-on-primary",
+          "disabled:bg-element-disabled",
+          "data-[disabled]:bg-element-disabled",
+        ],
+      },
+      size: {
+        md: ["h-10", "px-4", "gap-1.5", "rounded-xl", "after:rounded-xl"],
+        sm: [
+          "h-8",
+          "px-3",
+          "gap-1.5",
+          "text-sm",
+          "rounded-lg",
+          "after:rounded-lg",
+        ],
+      },
+      iconOnly: {
+        true: ["h-fit"],
+      },
+      fullWidth: {
+        true: "w-full",
+      },
+      disabled: {
+        true: ["cursor-not-allowed"],
+      },
+    },
+    compoundVariants: [
+      {
+        size: "md",
+        iconOnly: true,
+        className: "w-10 h-10 px-0",
+      },
+      {
+        size: "sm",
+        iconOnly: true,
+        className: "w-8 h-8 px-0",
+      },
+    ],
+    defaultVariants: {
+      variant: "primary",
+      size: "md",
+    },
+  },
+  {
+    responsiveVariants: true,
+  }
+);
+
+export type ButtonVariants = VariantProps<typeof buttonTheme>;

--- a/src/common/components/Button/Button.theme.ts
+++ b/src/common/components/Button/Button.theme.ts
@@ -35,7 +35,6 @@ export const buttonTheme = tv(
       "duration-300",
       "after:inset-0",
       "after:absolute",
-      "focus:outline-none",
       "hover:after:bg-white/10",
       "active:after:bg-transparent",
       "border",
@@ -69,6 +68,13 @@ export const buttonTheme = tv(
           "text-text-on-tertiary",
           "disabled:bg-element-disabled",
           "data-[disabled]:bg-element-disabled",
+        ],
+        link: [
+          "text-primary-default",
+          "hover:underline",
+          "hover:after:bg-transparent",
+          "disabled:text-text-placeholder",
+          "data-[disabled]:text-text-placeholder",
         ],
         success: [
           "bg-green-600",
@@ -114,6 +120,16 @@ export const buttonTheme = tv(
         size: "sm",
         iconOnly: true,
         className: "w-8 h-8 px-0",
+      },
+      {
+        variant: "link",
+        size: "md",
+        className: "px-0",
+      },
+      {
+        variant: "link",
+        size: "sm",
+        className: "px-0",
       },
     ],
     defaultVariants: {

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -49,6 +49,7 @@ export const Button = ({
   const Component = useCallback(
     ({ children: _children, ..._props }: ButtonOrLinkProps) => {
       // Accessing .as instead of destructuring to make use of discriminated unions
+      // https://github.com/microsoft/TypeScript/issues/46318
       if (_props.as === "a") {
         // Has an unused `as` to remove it from baseLinkProps
         // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -1,0 +1,146 @@
+import Link from "next/link";
+import {
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  useCallback,
+  isValidElement,
+  Children,
+  type HTMLProps,
+  cloneElement,
+  type ReactElement,
+} from "react";
+
+import {
+  buttonIconTheme,
+  buttonTheme,
+  type ButtonVariants,
+} from "./Button.theme";
+
+interface ButtonBaseProps {
+  iconLeft?: ReactNode;
+  iconRight?: ReactNode;
+  isResponsive?: boolean;
+}
+
+export interface ButtonLinkProps extends ComponentPropsWithoutRef<"a"> {
+  as?: "a";
+  external?: boolean;
+  href: string;
+}
+
+export interface ButtonProps extends ComponentPropsWithoutRef<"button"> {
+  as?: "button";
+}
+
+// Discriminated union based on "as" prop
+export type ButtonOrLinkProps = (ButtonLinkProps | ButtonProps) &
+  ButtonBaseProps &
+  Omit<ButtonVariants, "hasIcon" | "iconOnly">;
+
+export const Button = ({
+  children,
+  iconLeft,
+  iconRight,
+  isResponsive = false,
+  ...props
+}: ButtonOrLinkProps) => {
+  // Conditionally render between <NextLink>, <a> or <button> depending on props
+  // useCallback to prevent unnecessary re-rendering
+  const Component = useCallback(
+    ({ children: _children, ..._props }: ButtonOrLinkProps) => {
+      // Accessing .as instead of destructuring to make use of discriminated unions
+      if (_props.as === "a") {
+        // Has an unused `as` to remove it from baseLinkProps
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { external, href, as, ...baseLinkProps } = _props;
+
+        // External link
+        if (external) {
+          const externalLinkProps = {
+            target: "_blank",
+            rel: "noopener",
+            href,
+            ...baseLinkProps,
+          };
+          return <a {...externalLinkProps}>{_children}</a>;
+        }
+
+        // Internal link
+        return (
+          <Link {...baseLinkProps} href={href}>
+            {_children}
+          </Link>
+        );
+      } else {
+        const buttonProps = _props as ButtonProps;
+        return <button {...buttonProps}>{_children}</button>;
+      }
+    },
+    []
+  );
+
+  // Self invoking function to pick only props used in ButtonVariants
+  const styleProps = (({
+    variant = "primary",
+    iconOnly,
+    size = "md",
+    as,
+    fullWidth = false,
+    disabled = false,
+  }) => ({
+    variant,
+    iconOnly,
+    size,
+    as,
+    fullWidth,
+    disabled,
+  }))({
+    ...props,
+    iconOnly: typeof children === "undefined",
+    hasIcon: !!iconLeft || !!iconRight,
+  });
+
+  // throw error to pass aria-label if button is icon only
+  if (typeof children === "undefined" && !props["aria-label"]) {
+    throw new Error(
+      "Button must have a label if it is icon only. Please add an aria-label prop."
+    );
+  }
+
+  const StyledIcon = useCallback(
+    ({ icon }: { icon: ReactNode }) => {
+      if (isValidElement(icon)) {
+        return Children.map(icon, (child) => {
+          const originalClassName = (child.props as HTMLProps<HTMLOrSVGElement>)
+            ?.className;
+          return cloneElement(child as ReactElement, {
+            className: buttonIconTheme({
+              size: styleProps?.size,
+              className: originalClassName, // overriding icon classNames
+            }),
+          });
+        });
+      }
+      return <></>;
+    },
+    [styleProps?.size]
+  );
+
+  return (
+    <Component
+      {...props}
+      className={buttonTheme({
+        ...styleProps,
+        ...(isResponsive && {
+          size: { initial: "md", sm: "sm", md: "md" },
+        }),
+        className: props.className,
+      })}
+      data-disabled={props?.disabled ? "" : undefined}
+    >
+      <StyledIcon icon={iconLeft} />
+      {children}
+      <StyledIcon icon={iconRight} />
+    </Component>
+  );
+};

--- a/src/common/components/Button/index.ts
+++ b/src/common/components/Button/index.ts
@@ -1,0 +1,1 @@
+export * from "./Button";

--- a/src/common/components/Button/index.ts
+++ b/src/common/components/Button/index.ts
@@ -1,1 +1,2 @@
 export * from "./Button";
+export * from "./Button.theme";

--- a/src/common/styles/components.scss
+++ b/src/common/styles/components.scss
@@ -1,5 +1,5 @@
 @layer components {
   .focus-ring {
-    @apply focus-within:border-primary-default focus-within:ring-2 focus-within:ring-primary-default/20;
+    @apply focus-visible:border-primary-default focus-visible:ring-2 focus-visible:ring-primary-default/20;
   }
 }

--- a/src/common/tools/tailwind/themes/appTheme.ts
+++ b/src/common/tools/tailwind/themes/appTheme.ts
@@ -19,6 +19,7 @@ export const appTheme = {
     element: {
       secondary: rgb("--app-element-secondary"),
       tertiary: rgb("--app-element-tertiary"),
+      disabled: rgb("--app-element-disabled"),
     },
     bg: {
       base: rgb("--app-bg-base"),
@@ -29,6 +30,8 @@ export const appTheme = {
       elevated: rgb("--app-surface-elevated"),
     },
     border: {
+      primary: rgb("--app-border-primary"),
+      secondary: rgb("--app-border-secondary"),
       default: rgb("--app-border-default"),
       elevated: rgb("--app-border-elevated"),
     },

--- a/src/common/tools/tailwind/themes/darkTheme.ts
+++ b/src/common/tools/tailwind/themes/darkTheme.ts
@@ -22,6 +22,7 @@ export const darkThemeConfig = (_twConfig: Partial<Config> = {}) => {
       element: {
         secondary: "#1A1344",
         tertiary: "#14131B",
+        disabled: "#1E1E1F",
       },
       bg: {
         base: "#131316",
@@ -32,6 +33,8 @@ export const darkThemeConfig = (_twConfig: Partial<Config> = {}) => {
         elevated: "#232329",
       },
       border: {
+        primary: "#5A74FC",
+        secondary: "#241A5B",
         default: "#2D2D39",
         elevated: "#373743",
       },
@@ -39,9 +42,9 @@ export const darkThemeConfig = (_twConfig: Partial<Config> = {}) => {
         "on-primary": "#F2F2F3",
         "on-secondary": "#9485E5",
         "on-tertiary": "#A2A2A9",
-        "em-high": "#D7D7DA",
-        "em-mid": "#888891",
-        "em-low": "#62626A",
+        "em-high": "#F2F2F3",
+        "em-mid": "#A2A2A9",
+        "em-low": "#7A7A85",
         placeholder: "#494950",
         error: "#DC2626",
       },

--- a/src/common/tools/tailwind/themes/lightTheme.ts
+++ b/src/common/tools/tailwind/themes/lightTheme.ts
@@ -22,24 +22,27 @@ export const lightThemeConfig = (_twConfig: Partial<Config> = {}) => {
       element: {
         secondary: "#E1DDF8",
         tertiary: "#E5E4EC",
+        disabled: "#DDDDDF",
       },
       bg: {
         base: "#F1F1F3",
         alt: "#ECECEF",
       },
       surface: {
-        base: "#EBEBEF",
-        elevated: "#E2E2E9",
+        base: "#ECECEF",
+        elevated: "#E6E6EA",
       },
       border: {
-        default: "#D6D6E6",
-        elevated: "#CBCBDC",
+        primary: "#432CC3",
+        secondary: "#D4CEF2",
+        default: "#D7D7DF",
+        elevated: "#D1D1DC",
       },
       text: {
         "on-primary": "#F2F2F3",
         "on-secondary": "#5039D4",
         "on-tertiary": "#56565D",
-        "em-high": "#17171C",
+        "em-high": "#070708",
         "em-mid": "#56565D",
         "em-low": "#7A7A85",
         placeholder: "#AFAFB6",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/common/components/Input";
 import { APP_THEMES } from "@/common/tools/tailwind/themes/appTheme";
 import { supabase } from "@/server/supabase";
 import { api } from "@/utils/api";
+import { Button } from "@/common/components/Button";
 
 export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
@@ -27,7 +28,7 @@ export default function Home() {
   return (
     <>
       <PageHead name="AfterClass" />
-      <section className="flex h-full flex-col items-center space-y-6 p-6">
+      <section className="flex min-h-full flex-col items-center space-y-6 p-6">
         <div className="font-display font-semibold text-primary-default">
           AfterClass
         </div>
@@ -66,6 +67,49 @@ export default function Home() {
             size={{ initial: "sm", md: "md" }}
             isError={true}
           />
+        </div>
+        <div className="space-y-4">
+          <Button fullWidth>Full width</Button>
+          <div className="flex gap-3">
+            <Button>Primary</Button>
+            <Button size="sm" iconLeft={<StarLineAltIcon />}>
+              Small
+            </Button>
+            <Button aria-label="star" iconLeft={<StarLineAltIcon />} />
+            <Button
+              size="sm"
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+            />
+          </div>
+          <div className="flex gap-3">
+            <Button variant="secondary">Secondary</Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              iconRight={<StarLineAltIcon />}
+            >
+              Small
+            </Button>
+          </div>
+          <div className="flex gap-3">
+            <Button variant="tertiary">Tertiary</Button>
+            <Button variant="tertiary" size="sm">
+              Small
+            </Button>
+          </div>
+          <div className="flex gap-3">
+            <Button variant="success">Success</Button>
+            <Button variant="success" size="sm">
+              Small
+            </Button>
+          </div>
+          <div className="flex gap-3">
+            <Button variant="danger">Danger</Button>
+            <Button variant="danger" size="sm">
+              Small
+            </Button>
+          </div>
         </div>
       </section>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -110,6 +110,21 @@ export default function Home() {
               Small
             </Button>
           </div>
+          <div className="flex gap-3">
+            <Button
+              variant="link"
+              iconLeft={<Icon icon="lucide:arrow-up-right" />}
+              iconRight={<Icon icon="lucide:arrow-up-right" />}
+              as="a"
+              external
+              href="https://example.com"
+            >
+              Example.com
+            </Button>
+            <Button variant="link" size="sm" as="a" href="/login">
+              Login
+            </Button>
+          </div>
         </div>
       </section>
     </>


### PR DESCRIPTION
# Changes
- Update theme colors to match latest Figma
- Add Button component
- Button component is polymorphic, and depending on `as = 'a' | 'button'` prop, it will render an anchor tag or NextLink comp or button tag. 
- If it includes `external` prop + `as = 'a'`, then the button will use `target='_blank'`

# Screenshots

![CleanShot 2023-11-01 at 22 13 22@2x](https://github.com/AfterClass-io/afterclass.io-v2/assets/6003064/2481c5f1-d8b1-4e5a-ab55-cdbb1ef63898)

![CleanShot 2023-11-01 at 22 13 30@2x](https://github.com/AfterClass-io/afterclass.io-v2/assets/6003064/93b1a5d7-2b0f-4107-9885-4b621ef5ffff)

https://github.com/AfterClass-io/afterclass.io-v2/assets/6003064/ca251444-a10a-4e36-b728-33262b4d8bb4


# How to test

Go to the preview link and the buttons should be at the bottom