### PR TITLE
feat: button ghost, disabled and loading states

### DIFF
--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Button } from "@/common/components/Button";
+import { StarLineAltIcon } from "@/common/components/CustomIcon";
+import { Input } from "@/common/components/Input";
+import { APP_THEMES } from "@/common/tools/tailwind/themes/appTheme";
+import { Icon } from "@iconify-icon/react";
+import { useTheme } from "next-themes";
+import { useCallback, useEffect, useState } from "react";
+
+export const ComponentsPage = () => {
+  const [isMounted, setIsMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const handleToggleTheme = useCallback(() => {
+    if (theme === APP_THEMES.light) setTheme(APP_THEMES.dark);
+    if (theme === APP_THEMES.dark) setTheme(APP_THEMES.light);
+  }, [setTheme, theme]);
+
+  return (
+    <div className="space-y-10 p-5 sm:p-10">
+      {isMounted && (
+        <button
+          className="mx-auto flex items-center gap-2 rounded-md bg-primary-default p-3 text-text-on-primary"
+          // data-theme="light"
+          onClick={handleToggleTheme}
+        >
+          <Icon icon="uil:chart-line" width={16} />
+          <StarLineAltIcon size={16} />
+          <span>Toggle theme: Current {theme}</span>
+        </button>
+      )}
+      <div className="space-y-4">
+        <Button fullWidth>Full width</Button>
+        <div className="flex gap-3">
+          <Button>Primary</Button>
+          <Button size="sm" iconLeft={<StarLineAltIcon />}>
+            Small
+          </Button>
+          <Button aria-label="star" iconLeft={<StarLineAltIcon />} />
+          <Button size="sm" aria-label="star" iconLeft={<StarLineAltIcon />} />
+        </div>
+        <div className="flex gap-3">
+          <Button variant="secondary">Secondary</Button>
+          <Button variant="secondary" size="sm" iconRight={<StarLineAltIcon />}>
+            Small
+          </Button>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="tertiary">Tertiary</Button>
+          <Button variant="tertiary" size="sm">
+            Small
+          </Button>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="success">Success</Button>
+          <Button variant="success" size="sm">
+            Small
+          </Button>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="danger">Danger</Button>
+          <Button variant="danger" size="sm">
+            Small
+          </Button>
+        </div>
+        <div className="flex gap-3">
+          <Button
+            variant="link"
+            iconLeft={<Icon icon="lucide:arrow-up-right" />}
+            iconRight={<Icon icon="lucide:arrow-up-right" />}
+            as="a"
+            external
+            href="https://example.com"
+          >
+            Example.com
+          </Button>
+          <Button variant="link" size="sm" as="a" href="/login">
+            Login
+          </Button>
+        </div>
+      </div>
+      <div className="space-y-4">
+        <Input
+          label={"Test Label 1"}
+          helperText={"Test helper text"}
+          leftContent={<StarLineAltIcon size={16} />}
+          rightContent={<StarLineAltIcon size={16} />}
+          placeholder="Write here"
+        />
+        <Input
+          label={"Test Label 2"}
+          helperText={"Test error helper text"}
+          leftContent={<StarLineAltIcon size={16} />}
+          rightContent={<StarLineAltIcon size={16} />}
+          placeholder="Write here"
+          size={{ initial: "sm", md: "md" }}
+          isError={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ComponentsPage;

--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@/common/components/Button";
+import { Button, type ButtonVariants } from "@/common/components/Button";
 import { StarLineAltIcon } from "@/common/components/CustomIcon";
 import { Input } from "@/common/components/Input";
 import { APP_THEMES } from "@/common/tools/tailwind/themes/appTheme";
@@ -8,7 +8,17 @@ import { Icon } from "@iconify-icon/react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
 
-export const ComponentsPage = () => {
+const buttonVariants = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "ghost",
+  "success",
+  "danger",
+  "link",
+] as ButtonVariants["variant"][];
+
+export default function Components() {
   const [isMounted, setIsMounted] = useState(false);
   const { theme, setTheme } = useTheme();
 
@@ -36,67 +46,91 @@ export const ComponentsPage = () => {
       )}
       <div className="space-y-4">
         <Button fullWidth>Full width</Button>
-        <div className="flex gap-3">
-          <Button>Primary</Button>
-          <Button size="sm" iconLeft={<StarLineAltIcon />}>
-            Small
-          </Button>
-          <Button aria-label="star" iconLeft={<StarLineAltIcon />} />
-          <Button size="sm" aria-label="star" iconLeft={<StarLineAltIcon />} />
-        </div>
-        <div className="flex gap-3">
-          <Button variant="secondary">Secondary</Button>
-          <Button variant="secondary" size="sm" iconRight={<StarLineAltIcon />}>
-            Small
-          </Button>
-        </div>
-        <div className="flex gap-3">
-          <Button variant="tertiary">Tertiary</Button>
-          <Button variant="tertiary" size="sm">
-            Small
-          </Button>
-        </div>
-        <div className="flex gap-3">
-          <Button variant="success">Success</Button>
-          <Button variant="success" size="sm">
-            Small
-          </Button>
-        </div>
-        <div className="flex gap-3">
-          <Button variant="danger">Danger</Button>
-          <Button variant="danger" size="sm">
-            Small
-          </Button>
-        </div>
-        <div className="flex gap-3">
-          <Button
-            variant="link"
-            iconLeft={<Icon icon="lucide:arrow-up-right" />}
-            iconRight={<Icon icon="lucide:arrow-up-right" />}
-            as="a"
-            external
-            href="https://example.com"
+        {/* Buttons */}
+        {buttonVariants.map((variant) => (
+          <div
+            key={variant as string}
+            className="flex max-w-[320px] flex-wrap gap-3"
           >
-            Example.com
-          </Button>
-          <Button variant="link" size="sm" as="a" href="/login">
-            Login
-          </Button>
-        </div>
+            <Button variant={variant}>{variant as string}</Button>
+            <Button variant={variant} size="sm" iconLeft={<StarLineAltIcon />}>
+              Small
+            </Button>
+            <Button
+              variant={variant}
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+            />
+            <Button
+              variant={variant}
+              size="sm"
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+            />
+            <Button variant={variant} loading>
+              {variant as string}
+            </Button>
+            <Button
+              variant={variant}
+              size="sm"
+              iconLeft={<StarLineAltIcon />}
+              loading
+            >
+              Small
+            </Button>
+            <Button
+              variant={variant}
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+              loading
+            />
+            <Button
+              variant={variant}
+              size="sm"
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+              loading
+            />
+            <Button variant={variant} disabled>
+              {variant as string}
+            </Button>
+            <Button
+              variant={variant}
+              size="sm"
+              iconLeft={<StarLineAltIcon />}
+              disabled
+            >
+              Small
+            </Button>
+            <Button
+              variant={variant}
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+              disabled
+            />
+            <Button
+              variant={variant}
+              size="sm"
+              aria-label="star"
+              iconLeft={<StarLineAltIcon />}
+              disabled
+            />
+          </div>
+        ))}
       </div>
       <div className="space-y-4">
         <Input
           label={"Test Label 1"}
           helperText={"Test helper text"}
-          leftContent={<StarLineAltIcon size={16} />}
-          rightContent={<StarLineAltIcon size={16} />}
+          contentLeft={<StarLineAltIcon size={16} />}
+          contentRight={<StarLineAltIcon size={16} />}
           placeholder="Write here"
         />
         <Input
           label={"Test Label 2"}
           helperText={"Test error helper text"}
-          leftContent={<StarLineAltIcon size={16} />}
-          rightContent={<StarLineAltIcon size={16} />}
+          contentLeft={<StarLineAltIcon size={16} />}
+          contentRight={<StarLineAltIcon size={16} />}
           placeholder="Write here"
           size={{ initial: "sm", md: "md" }}
           isError={true}
@@ -104,6 +138,4 @@ export const ComponentsPage = () => {
       </div>
     </div>
   );
-};
-
-export default ComponentsPage;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,34 +21,12 @@ export default function Home() {
   // Get all universities
   const universities = api.university.getAll.useQuery();
 
-  const [isMounted, setIsMounted] = useState(false);
-  const { theme, setTheme } = useTheme();
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  const handleToggleTheme = useCallback(() => {
-    if (theme === APP_THEMES.light) setTheme(APP_THEMES.dark);
-    if (theme === APP_THEMES.dark) setTheme(APP_THEMES.light);
-  }, [setTheme, theme]);
-
   return (
     <>
       <section className="flex h-full flex-col items-center space-y-6 p-6">
         <div className="font-display font-semibold text-primary-default">
           AfterClass
         </div>
-        {isMounted && (
-          <button
-            className="mx-auto flex items-center gap-2 rounded-md bg-primary-default p-3 text-text-on-primary"
-            // data-theme="light"
-            onClick={handleToggleTheme}
-          >
-            <Icon icon="uil:chart-line" width={16} />
-            <StarLineAltIcon size={16} />
-            <span>Toggle theme: Current {theme}</span>
-          </button>
-        )}
         <div className="mx-auto flex w-fit flex-col items-center justify-center gap-3 rounded-md bg-bg-alt p-6">
           <span>tRPC Auth showcase</span>
           <span>
@@ -60,82 +38,6 @@ export default function Home() {
                 ))
               : "Loading tRPC query..."}
           </span>
-        </div>
-        <div className="space-y-4">
-          <Input
-            label={"Test Label 1"}
-            helperText={"Test helper text"}
-            contentLeft={<StarLineAltIcon size={16} />}
-            contentRight={<StarLineAltIcon size={16} />}
-            placeholder="Write here"
-          />
-          <Input
-            label={"Test Label 2"}
-            helperText={"Test error helper text"}
-            contentLeft={<StarLineAltIcon size={16} />}
-            contentRight={<StarLineAltIcon size={16} />}
-            placeholder="Write here"
-            size={{ initial: "sm", md: "md" }}
-            isError={true}
-          />
-        </div>
-        <div className="space-y-4">
-          <Button fullWidth>Full width</Button>
-          <div className="flex gap-3">
-            <Button>Primary</Button>
-            <Button size="sm" iconLeft={<StarLineAltIcon />}>
-              Small
-            </Button>
-            <Button aria-label="star" iconLeft={<StarLineAltIcon />} />
-            <Button
-              size="sm"
-              aria-label="star"
-              iconLeft={<StarLineAltIcon />}
-            />
-          </div>
-          <div className="flex gap-3">
-            <Button variant="secondary">Secondary</Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              iconRight={<StarLineAltIcon />}
-            >
-              Small
-            </Button>
-          </div>
-          <div className="flex gap-3">
-            <Button variant="tertiary">Tertiary</Button>
-            <Button variant="tertiary" size="sm">
-              Small
-            </Button>
-          </div>
-          <div className="flex gap-3">
-            <Button variant="success">Success</Button>
-            <Button variant="success" size="sm">
-              Small
-            </Button>
-          </div>
-          <div className="flex gap-3">
-            <Button variant="danger">Danger</Button>
-            <Button variant="danger" size="sm">
-              Small
-            </Button>
-          </div>
-          <div className="flex gap-3">
-            <Button
-              variant="link"
-              iconLeft={<Icon icon="lucide:arrow-up-right" />}
-              iconRight={<Icon icon="lucide:arrow-up-right" />}
-              as="a"
-              external
-              href="https://example.com"
-            >
-              Example.com
-            </Button>
-            <Button variant="link" size="sm" as="a" href="/login">
-              Login
-            </Button>
-          </div>
         </div>
       </section>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,5 @@
-"use client";
+"use client"; // Remove this when we remove api calls directly in page
 
-import { useState, useEffect, useCallback } from "react";
-import { useTheme } from "next-themes";
-import { Icon } from "@iconify-icon/react";
-
-import { APP_THEMES } from "@/common/tools/tailwind/themes/appTheme";
-import { Button } from "@/common/components/Button";
-import { Input } from "@/common/components/Input";
-import { StarLineAltIcon } from "@/common/components/CustomIcon";
 import { api } from "@/common/tools/trpc/utils/api";
 
 export default function Home() {
@@ -28,7 +20,6 @@ export default function Home() {
           AfterClass
         </div>
         <div className="mx-auto flex w-fit flex-col items-center justify-center gap-3 rounded-md bg-bg-alt p-6">
-          <span>tRPC Auth showcase</span>
           <span>
             {universities.data
               ? universities.data.map((university) => (

--- a/src/common/components/Button/Button.theme.ts
+++ b/src/common/components/Button/Button.theme.ts
@@ -16,7 +16,7 @@ export const buttonIconTheme = tv(
       },
     },
   },
-  { responsiveVariants: true }
+  { responsiveVariants: true },
 );
 
 export const buttonTheme = tv(
@@ -109,6 +109,11 @@ export const buttonTheme = tv(
       disabled: {
         true: ["cursor-not-allowed"],
       },
+      loading: {
+        true: {
+          base: ["hover:after:bg-transparent", "[&>*:not(.loading)]:invisible"],
+        },
+      },
     },
     compoundVariants: [
       {
@@ -139,7 +144,7 @@ export const buttonTheme = tv(
   },
   {
     responsiveVariants: true,
-  }
+  },
 );
 
 export type ButtonVariants = VariantProps<typeof buttonTheme>;

--- a/src/common/components/Button/Button.theme.ts
+++ b/src/common/components/Button/Button.theme.ts
@@ -31,11 +31,11 @@ export const buttonTheme = tv(
       "items-center",
       "font-semibold",
       "focus-ring",
-      "transition-all",
-      "duration-300",
+      "after:transition-all",
+      "after:duration-100",
       "after:inset-0",
       "after:absolute",
-      "hover:after:bg-white/10",
+      "hover:after:bg-white/[0.12]",
       "active:after:bg-transparent",
       "border",
       "border-transparent",
@@ -68,6 +68,14 @@ export const buttonTheme = tv(
           "text-text-on-tertiary",
           "disabled:bg-element-disabled",
           "data-[disabled]:bg-element-disabled",
+        ],
+        ghost: [
+          "bg-transparent",
+          "border-transparent",
+          "text-text-on-tertiary",
+          "disabled:bg-element-disabled",
+          "data-[disabled]:bg-element-disabled",
+          "hover:bg-element-tertiary",
         ],
         link: [
           "text-primary-default",
@@ -110,9 +118,11 @@ export const buttonTheme = tv(
         true: ["cursor-not-allowed"],
       },
       loading: {
-        true: {
-          base: ["hover:after:bg-transparent", "[&>*:not(.loading)]:invisible"],
-        },
+        true: [
+          "loading",
+          "hover:after:bg-transparent",
+          "[&>*:not(.loading)]:invisible",
+        ],
       },
     },
     compoundVariants: [
@@ -135,6 +145,11 @@ export const buttonTheme = tv(
         variant: "link",
         size: "sm",
         className: "px-0",
+      },
+      {
+        variant: "ghost",
+        loading: true,
+        className: "hover:bg-transparent",
       },
     ],
     defaultVariants: {

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -42,6 +42,7 @@ export const Button = ({
   iconLeft,
   iconRight,
   isResponsive = false,
+  fullWidth,
   ...props
 }: ButtonOrLinkProps) => {
   // Conditionally render between <NextLink>, <a> or <button> depending on props
@@ -77,7 +78,7 @@ export const Button = ({
         return <button {...buttonProps}>{_children}</button>;
       }
     },
-    []
+    [],
   );
 
   // Self invoking function to pick only props used in ButtonVariants
@@ -99,12 +100,13 @@ export const Button = ({
     ...props,
     iconOnly: typeof children === "undefined",
     hasIcon: !!iconLeft || !!iconRight,
+    fullWidth,
   });
 
   // throw error to pass aria-label if button is icon only
   if (typeof children === "undefined" && !props["aria-label"]) {
     throw new Error(
-      "Button must have a label if it is icon only. Please add an aria-label prop."
+      "Button must have a label if it is icon only. Please add an aria-label prop.",
     );
   }
 
@@ -124,7 +126,7 @@ export const Button = ({
       }
       return <></>;
     },
-    [styleProps?.size]
+    [styleProps?.size],
   );
 
   return (

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -15,6 +15,7 @@ import {
   buttonTheme,
   type ButtonVariants,
 } from "./Button.theme";
+import { Icon } from "@iconify-icon/react";
 
 interface ButtonBaseProps {
   iconLeft?: ReactNode;
@@ -142,8 +143,13 @@ export const Button = ({
       data-disabled={disabled ? "" : undefined}
     >
       <StyledIcon icon={iconLeft} />
-      {children}
+      {children && <span>{children}</span>}
       <StyledIcon icon={iconRight} />
+      {loading && (
+        <span className="loading absolute inset-0 grid place-content-center">
+          <Icon icon="gg:spinner" className="animate-spin" />
+        </span>
+      )}
     </Component>
   );
 };

--- a/src/common/components/Button/Button.tsx
+++ b/src/common/components/Button/Button.tsx
@@ -43,6 +43,8 @@ export const Button = ({
   iconRight,
   isResponsive = false,
   fullWidth,
+  disabled,
+  loading,
   ...props
 }: ButtonOrLinkProps) => {
   // Conditionally render between <NextLink>, <a> or <button> depending on props
@@ -82,25 +84,18 @@ export const Button = ({
   );
 
   // Self invoking function to pick only props used in ButtonVariants
-  const styleProps = (({
-    variant = "primary",
-    iconOnly,
-    size = "md",
-    as,
-    fullWidth = false,
-    disabled = false,
-  }) => ({
+  const styleProps = (({ variant = "primary", iconOnly, size = "md", as }) => ({
     variant,
     iconOnly,
     size,
     as,
     fullWidth,
     disabled,
+    loading,
   }))({
     ...props,
     iconOnly: typeof children === "undefined",
     hasIcon: !!iconLeft || !!iconRight,
-    fullWidth,
   });
 
   // throw error to pass aria-label if button is icon only
@@ -129,9 +124,14 @@ export const Button = ({
     [styleProps?.size],
   );
 
+  const disableOnClickProp = {
+    ...((loading ?? disabled) && { onClick: undefined }),
+  };
+
   return (
     <Component
       {...props}
+      {...disableOnClickProp}
       className={buttonTheme({
         ...styleProps,
         ...(isResponsive && {
@@ -139,7 +139,7 @@ export const Button = ({
         }),
         className: props.className,
       })}
-      data-disabled={props?.disabled ? "" : undefined}
+      data-disabled={disabled ? "" : undefined}
     >
       <StyledIcon icon={iconLeft} />
       {children}

--- a/src/common/components/CoreLayout/CoreLayout.tsx
+++ b/src/common/components/CoreLayout/CoreLayout.tsx
@@ -7,7 +7,7 @@ interface Props extends PropsWithChildren {}
 
 export const CoreLayout = ({ children }: Props) => {
   return (
-    <div className="relative flex h-full min-h-full flex-auto">
+    <div className="relative flex min-h-full flex-auto">
       <aside>
         <Sidebar />
       </aside>


### PR DESCRIPTION
## Changes
- Added `ghost` variant (transparent bg)
- Added `loading` button state 
- Disabled onClick for `loading` and `disabled` button states
- Moved components from `app/page.tsx` to `app/components/page.tsx`
- Updated showcase of buttons
- Add comment on app index page to remove 'use client'

## Screenshots

https://github.com/AfterClass-io/afterclass.io-v2/assets/6003064/5f266c96-8405-4e9d-9e1a-5ceeb67a1ef0

