### PR TITLE
feat(api): courses trpc router

### DIFF
--- a/src/app/(school)/page.tsx
+++ b/src/app/(school)/page.tsx
@@ -16,6 +16,13 @@ export default function Home() {
     universityId: 1,
     courseId: "2a45bab1-5ec4-4d2e-b245-27a142a78890",
   });
+  const publicCourses = api.courses.listByUni.useQuery({
+    universityId: 1,
+  });
+
+  const protectedCourses = api.courses.listByUniProtected.useQuery({
+    universityId: 1,
+  });
 
   return (
     <>
@@ -44,6 +51,36 @@ export default function Home() {
           {reviews.data
             ? reviews.data.map((review) => (
                 <div key={review.id}>{JSON.stringify(review)}</div>
+              ))
+            : "Loading tRPC query..."}
+        </div>
+        <div className="flex flex-col gap-6">
+          <div className="flex gap-2">
+            <span>Total:</span>
+            <span>
+              {publicCourses.data
+                ? publicCourses.data.length + " public courses"
+                : "loading..."}
+            </span>
+          </div>
+          {publicCourses.data
+            ? publicCourses.data.map((course) => (
+                <div key={course.id}>{JSON.stringify(course)}</div>
+              ))
+            : "Loading tRPC query..."}
+        </div>
+        <div className="flex flex-col gap-6">
+          <div className="flex gap-2">
+            <span>Total:</span>
+            <span>
+              {protectedCourses.data
+                ? protectedCourses.data.length + " protected courses"
+                : "loading..."}
+            </span>
+          </div>
+          {protectedCourses.data
+            ? protectedCourses.data.map((course) => (
+                <div key={course.id}>{JSON.stringify(course)}</div>
               ))
             : "Loading tRPC query..."}
         </div>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,4 +1,8 @@
-import { reviewsRouter, universityRouter } from "@/server/api/routers";
+import {
+  coursesRouter,
+  reviewsRouter,
+  universityRouter,
+} from "@/server/api/routers";
 import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
 
 /**
@@ -9,6 +13,7 @@ import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
 export const appRouter = createTRPCRouter({
   university: universityRouter,
   reviews: reviewsRouter,
+  courses: coursesRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/courses.ts
+++ b/src/server/api/routers/courses.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "@/server/api/trpc";
+
+const DEFAULT_PAGE_SIZE = 10;
+
+const PUBLIC_COURSE_FIELDS = {
+  id: true,
+  name: true,
+  code: true,
+  belongToFacultyId: true,
+  belongToFaculty: {
+    select: {
+      id: true,
+      name: true,
+      acronym: true,
+      siteUrl: true,
+    },
+  },
+  belongToUniversityId: true,
+  belongToUniversity: {
+    select: {
+      id: true,
+      name: true,
+      abbrv: true,
+      siteUrl: true,
+    },
+  },
+} satisfies Prisma.CoursesSelect;
+
+export const coursesRouter = createTRPCRouter({
+  listByUni: publicProcedure
+    .input(
+      z.object({
+        page: z.number().default(1),
+        universityId: z.number(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const courses = await ctx.db.courses.findMany({
+        skip: DEFAULT_PAGE_SIZE * (input.page - 1),
+        take: DEFAULT_PAGE_SIZE,
+        select: PUBLIC_COURSE_FIELDS,
+        where: {
+          belongToUniversityId: input.universityId,
+        },
+      });
+      return courses;
+    }),
+
+  listByFaculty: publicProcedure
+    .input(
+      z.object({
+        page: z.number().default(1),
+        facultyId: z.number(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const courses = await ctx.db.courses.findMany({
+        skip: DEFAULT_PAGE_SIZE * (input.page - 1),
+        take: DEFAULT_PAGE_SIZE,
+        select: PUBLIC_COURSE_FIELDS,
+        where: {
+          belongToFacultyId: input.facultyId,
+        },
+      });
+      return courses;
+    }),
+
+  listByUniProtected: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().default(1),
+        universityId: z.number(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const courses = await ctx.db.courses.findMany({
+        skip: DEFAULT_PAGE_SIZE * (input.page - 1),
+        take: DEFAULT_PAGE_SIZE,
+        where: {
+          belongToUniversityId: input.universityId,
+        },
+      });
+      return courses;
+    }),
+
+  listByFacultyProtected: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().default(1),
+        facultyId: z.number(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const courses = await ctx.db.courses.findMany({
+        skip: DEFAULT_PAGE_SIZE * (input.page - 1),
+        take: DEFAULT_PAGE_SIZE,
+        where: {
+          belongToFacultyId: input.facultyId,
+        },
+      });
+      return courses;
+    }),
+});

--- a/src/server/api/routers/index.ts
+++ b/src/server/api/routers/index.ts
@@ -1,2 +1,3 @@
 export * from "./university";
 export * from "./reviews";
+export * from "./courses";


### PR DESCRIPTION
closes #70

## Changes

- add courses trpc router
- add `listByUni` public endpoint
- add `listByFaculty` public endpoint
- add `listByUni` protected endpoint
- add `listByFaculty` protected endpoint
- example implemenation

## Testing

1. setup local dev env
   a. run `docker compose up`
   b. run `npx prisma migrate reset` to setup and seed the local db
2. navigate to `/`
3. sign in if needed
4. should see 10 courses from both private and protected endpoints. Private endpoint data should show more fields than public endpoint data