### PR TITLE
feat(ui): Textarea component

### DIFF
--- a/src/common/components/Textarea/Textarea.stories.tsx
+++ b/src/common/components/Textarea/Textarea.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Textarea } from "./Textarea";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Common/Textarea",
+  component: Textarea,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  args: {
+    placeholder: "Input",
+  },
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    return <Textarea {...args} />;
+  },
+};

--- a/src/common/components/Textarea/Textarea.theme.ts
+++ b/src/common/components/Textarea/Textarea.theme.ts
@@ -11,7 +11,7 @@ export const textareaTheme = tv(
         "items-start",
         "p-2",
         "w-80",
-        "max-w-[30rem]",
+        "max-w-[480px]",
         "min-h-32",
         "gap-2",
         "rounded-lg",

--- a/src/common/components/Textarea/Textarea.theme.ts
+++ b/src/common/components/Textarea/Textarea.theme.ts
@@ -16,7 +16,6 @@ export const textareaTheme = tv(
         "gap-2",
         "rounded-lg",
         "border",
-        "border-solid",
         "bg-surface-base",
         "border-border-default",
         "text-text-em-mid",

--- a/src/common/components/Textarea/Textarea.theme.ts
+++ b/src/common/components/Textarea/Textarea.theme.ts
@@ -25,11 +25,11 @@ export const textareaTheme = tv(
       size: {
         md: {
           wrapper: [],
-          textarea: ["text-sm"],
+          textarea: ["text-base"],
         },
         sm: {
           wrapper: [],
-          textarea: ["text-xs"],
+          textarea: ["text-sm"],
         },
       },
     },

--- a/src/common/components/Textarea/Textarea.theme.ts
+++ b/src/common/components/Textarea/Textarea.theme.ts
@@ -1,0 +1,39 @@
+import { type VariantProps, tv } from "tailwind-variants";
+
+export type TextareaVariants = VariantProps<typeof textareaTheme>;
+
+export const textareaTheme = tv(
+  {
+    slots: {
+      wrapper: [],
+      textarea: [
+        "flex",
+        "items-start",
+        "p-2",
+        "w-80",
+        "max-w-[30rem]",
+        "min-h-32",
+        "gap-2",
+        "rounded-lg",
+        "border",
+        "border-solid",
+        "bg-surface-base",
+        "border-border-default",
+        "text-text-em-mid",
+      ],
+    },
+    variants: {
+      size: {
+        md: {
+          wrapper: [],
+          textarea: ["text-sm"],
+        },
+        sm: {
+          wrapper: [],
+          textarea: ["text-xs"],
+        },
+      },
+    },
+  },
+  { responsiveVariants: true },
+);

--- a/src/common/components/Textarea/Textarea.tsx
+++ b/src/common/components/Textarea/Textarea.tsx
@@ -31,3 +31,4 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     );
   },
 );
+Textarea.displayName = "Textarea";

--- a/src/common/components/Textarea/Textarea.tsx
+++ b/src/common/components/Textarea/Textarea.tsx
@@ -1,0 +1,33 @@
+import { type ComponentPropsWithoutRef, forwardRef } from "react";
+import { type TextareaVariants, textareaTheme } from "./Textarea.theme";
+
+export type TextareaProps = ComponentPropsWithoutRef<"textarea"> &
+  TextareaVariants & {
+    placeholder?: string;
+    wrapperProps?: ComponentPropsWithoutRef<"div">;
+  };
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    { placeholder = "Input", size = "md", wrapperProps, className, ...props },
+    ref,
+  ) => {
+    const { wrapper, textarea } = textareaTheme();
+    return (
+      <div
+        className={wrapper({
+          className: wrapperProps?.className,
+          size,
+        })}
+        {...wrapperProps}
+      >
+        <textarea
+          placeholder={placeholder}
+          className={textarea({ className, size })}
+          ref={ref}
+          {...props}
+        />
+      </div>
+    );
+  },
+);

--- a/src/common/components/Textarea/index.ts
+++ b/src/common/components/Textarea/index.ts
@@ -1,0 +1,2 @@
+export * from "./Textarea";
+export * from "./Textarea.theme";


### PR DESCRIPTION
closes #33 

## changes

- \+ `Textarea` component
- \+ `Textarea` story

## implementation

- left out the left / right icon/content component

## testing

- [Chromatic build review](https://www.chromatic.com/build?appId=65e66a97ccf98da794749891&number=22)
- [Storybooks on Chromatic](https://65e66a97ccf98da794749891-fipsuwccgh.chromatic.com)

## preview

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/0ef46370-9380-450d-b325-9f29dbd15e10)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/dd9a07d9-e06f-42ce-a1ce-0525a10e1edd)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/6bc9ad68-4333-4746-83a3-3e2c82667660)
