### PR TITLE
fix: unintentional disabling of `Command` after upgrading cmdk to v1.x

### DIFF
--- a/src/common/components/Command/Command.theme.ts
+++ b/src/common/components/Command/Command.theme.ts
@@ -84,8 +84,8 @@ export const commandTheme = tv(
         "py-1.5",
         "text-sm",
         "outline-none",
-        "data-[disabled]:pointer-events-none",
-        "data-[disabled]:opacity-50",
+        "data-[disabled='true']:pointer-events-none",
+        "data-[disabled='true']:opacity-50",
       ],
       commandShortcut: [
         "ml-auto",

--- a/src/modules/reviews/Combobox.tsx
+++ b/src/modules/reviews/Combobox.tsx
@@ -42,30 +42,32 @@ export const Combobox = ({
           <Command.Input placeholder={placeholder} />
           <Command.Separator />
           <Command.Empty>Nothing found.</Command.Empty>
-          <Command.Group>
-            {items.map((el) => (
-              <Command.Item
-                id={el.value}
-                key={el.value}
-                value={el.value}
-                onSelect={(selectedValue) => {
-                  setValue(selectedValue === value ? "" : selectedValue);
-                  setOpen(false);
-                  onSelectChange?.(selectedValue);
-                }}
-                aria-selected={isMatched(el.value)}
-                data-selected={isMatched(el.value) ? "" : undefined}
-              >
-                <CheckIcon
-                  className={cn(
-                    "text-primary-default",
-                    isMatched(el.value) ? "visible" : "invisible",
-                  )}
-                />
-                {el.label}
-              </Command.Item>
-            ))}
-          </Command.Group>
+          <Command.List>
+            <Command.Group>
+              {items.map((el) => (
+                <Command.Item
+                  id={el.value}
+                  key={el.value}
+                  value={el.value}
+                  onSelect={(selectedValue) => {
+                    setValue(selectedValue === value ? "" : selectedValue);
+                    setOpen(false);
+                    onSelectChange?.(selectedValue);
+                  }}
+                  aria-selected={isMatched(el.value)}
+                  data-selected={isMatched(el.value) ? "" : undefined}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "text-primary-default",
+                      isMatched(el.value) ? "visible" : "invisible",
+                    )}
+                  />
+                  {el.label}
+                </Command.Item>
+              ))}
+            </Command.Group>
+          </Command.List>
         </Command>
       </Popover.Content>
     </Popover>


### PR DESCRIPTION
## context

upgrading to cmdk v1.x ([`3684199`](https://github.com/AfterClass-io/afterclass.io-v2/pull/75/commits/36841994fbe679b565d38aa1a512536b926a4e83#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L33-R33)) broke `Command` component, which also impacted `Combobox` component

- [command component story @`main`](https://65e66a97ccf98da794749891-fipsuwccgh.chromatic.com/?path=/docs/common-command--docs)
- [combobox component story @`main`](https://65e66a97ccf98da794749891-fipsuwccgh.chromatic.com/?path=/docs/common-combobox--docs)

## the fix

comment with elaborated solution
`https://github.com/shadcn-ui/ui/issues/2980#issuecomment-2029267475`

cmdk [v1.0.0 release notes](https://github.com/pacocoursey/cmdk/releases/tag/v1.0.0):
> `Command.List` is now required (`CommandList` in `shadcn`)
>
> ```tsx
> // Before
> <Command label="Command Menu">
> 	<Command.Input />
> 	<Command.Item />
> 	{/* ... */}
> </Command>
> ```
> ```tsx
> // After
> <Command label="Command Menu">
> 	<Command.Input />
> 	<Command.List>
> 		<Command.Item />
> 		{/* ... */}
> 	</Command.List>
> </Command>
> ```

> The aria-disabled and aria-selected props will now be set to false, instead of being undefined. If you previously used CSS selectors based on attribute presence, you will now need to use the attribute value.
>
> ```css
> /* Before */
> [aria-disabled] {}
> :not([aria-disabled]) {}
>
> /* After */
> [aria-disabled="true"] {}
> [aria-disabled="false"] {}
> ```