### PR TITLE
feat(ui): `SchoolTag` component

### DIFF
--- a/src/common/components/SchoolTag/SchoolTag.stories.tsx
+++ b/src/common/components/SchoolTag/SchoolTag.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { SchoolTag } from "./SchoolTag";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Common/SchoolTag",
+  component: SchoolTag,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  args: {
+    school: "SMU",
+  },
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+} satisfies Meta<typeof SchoolTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const NUS: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    school: "NUS",
+  },
+};
+
+export const NTU: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    school: "NTU",
+  },
+};

--- a/src/common/components/SchoolTag/SchoolTag.theme.ts
+++ b/src/common/components/SchoolTag/SchoolTag.theme.ts
@@ -1,0 +1,10 @@
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const schoolTagTheme = tv({
+  slots: {
+    heading: ["text-sm"],
+    tagIcon: ["h-6", "w-6"],
+  },
+});
+
+export type SchoolTagVariants = VariantProps<typeof schoolTagTheme>;

--- a/src/common/components/SchoolTag/SchoolTag.tsx
+++ b/src/common/components/SchoolTag/SchoolTag.tsx
@@ -1,0 +1,22 @@
+import {
+  SchoolIcon,
+  type SchoolIconProps,
+} from "@/common/components/CustomIcon";
+import Heading from "@/common/components/Heading";
+import { Tag } from "@/common/components/Tag";
+import { schoolTagTheme } from "./SchoolTag.theme";
+
+export const SchoolTag = ({
+  school,
+}: {
+  school: SchoolIconProps["school"];
+}) => {
+  const { tagIcon, heading } = schoolTagTheme();
+  return (
+    <Tag contentLeft={<SchoolIcon className={tagIcon()} school={school} />}>
+      <Heading as="h5" className={heading()}>
+        {school}
+      </Heading>
+    </Tag>
+  );
+};

--- a/src/common/components/SchoolTag/index.ts
+++ b/src/common/components/SchoolTag/index.ts
@@ -1,0 +1,2 @@
+export * from "./SchoolTag";
+export * from "./SchoolTag.theme";

--- a/src/common/components/Tag/Tag.theme.ts
+++ b/src/common/components/Tag/Tag.theme.ts
@@ -8,7 +8,7 @@ export const tagTheme = tv(
       tag: [
         "inline-flex",
         "min-w-14",
-        "py-[0.125rem]",
+        "py-[0.38rem]",
         "px-3",
         "gap-2",
         "justify-center",


### PR DESCRIPTION
## changes

- \+ `SchoolTag` Component

## implementation

- use school icon
- update `<Tag/>` default y-padding to be double of original
- use `<Heading/>` component for school name

## testing

- [Chromatic build review](https://www.chromatic.com/build?appId=65e66a97ccf98da794749891&number=52)
- [Storybooks on Chromatic](https://65e66a97ccf98da794749891-ekswsrezhn.chromatic.com/)

## preview

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/7e071d07-1ebe-4e76-bebb-1b44fd28f7ec)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/c1cbab3f-d6bd-4cfe-b0c0-cc461cf411f9)
