### PR TITLE
feat(ui): `PageTitle` component

### DIFF
--- a/src/common/components/PageTitle/PageTitle.stories.tsx
+++ b/src/common/components/PageTitle/PageTitle.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import {
+  BooksIcon,
+  SchoolIcon,
+  StarLineAltIcon,
+} from "@/common/components/CustomIcon";
+
+import { PageTitle } from "./PageTitle";
+import { Tag } from "@/common/components/Tag";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Common/PageTitle",
+  component: PageTitle,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  args: {
+    contentLeft: <BooksIcon className="h-6 w-6" />,
+    contentRight: (
+      <Tag contentLeft={<SchoolIcon school="SMU" className="h-6 w-6" />}>
+        SMU
+      </Tag>
+    ),
+    children: "Business, Government and Society",
+  },
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+} satisfies Meta<typeof PageTitle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/common/components/PageTitle/PageTitle.stories.tsx
+++ b/src/common/components/PageTitle/PageTitle.stories.tsx
@@ -1,10 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import {
-  BooksIcon,
-  SchoolIcon,
-  StarLineAltIcon,
-} from "@/common/components/CustomIcon";
+import { BooksIcon, SchoolIcon } from "@/common/components/CustomIcon";
 
 import { PageTitle } from "./PageTitle";
 import { Tag } from "@/common/components/Tag";

--- a/src/common/components/PageTitle/PageTitle.theme.ts
+++ b/src/common/components/PageTitle/PageTitle.theme.ts
@@ -1,0 +1,10 @@
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const pageTitleTheme = tv({
+  slots: {
+    wrapper: ["inline-flex", "pb-2", "items-center", "gap-6"],
+    heading: ["text-center", "text-3xl"],
+  },
+});
+
+export type PageTitleVariants = VariantProps<typeof pageTitleTheme>;

--- a/src/common/components/PageTitle/PageTitle.tsx
+++ b/src/common/components/PageTitle/PageTitle.tsx
@@ -1,0 +1,25 @@
+import Heading from "@/common/components/Heading";
+import { pageTitleTheme } from "./PageTitle.theme";
+
+export type PageTitleProps = {
+  children: React.ReactNode;
+  contentLeft?: React.ReactNode;
+  contentRight?: React.ReactNode;
+};
+
+export const PageTitle = ({
+  children,
+  contentLeft,
+  contentRight,
+}: PageTitleProps) => {
+  const { wrapper, heading } = pageTitleTheme();
+  return (
+    <div className={wrapper()}>
+      {contentLeft}
+      <Heading className={heading()} as="h1">
+        {children}
+      </Heading>
+      {contentRight}
+    </div>
+  );
+};

--- a/src/common/components/PageTitle/index.ts
+++ b/src/common/components/PageTitle/index.ts
@@ -1,0 +1,2 @@
+export * from "./PageTitle";
+export * from "./PageTitle.theme";


### PR DESCRIPTION
## changes

- \+ `PageTitle` Component

## implementation

- use `<Heading/>` component for the main title
- accepts `children` as prop and passes to `<Heading/>`
- accepts left and right content to be placed beside `<Heading/>`

## testing

- [Chromatic build review](https://www.chromatic.com/build?appId=65e66a97ccf98da794749891&number=53)
- [Storybooks on Chromatic](https://65e66a97ccf98da794749891-slyaxyitoo.chromatic.com/)

## preview

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/3033c042-a7e9-4c2d-bcbf-2694cb1a4691)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/4c79a275-59a4-4187-b905-4fda3efa4a0c)
