### PR TITLE
feat: Email verification after sign up

### DIFF
--- a/src/app/account/auth/confirm-signup/page.tsx
+++ b/src/app/account/auth/confirm-signup/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { AuthCard, ConfirmSignUpNote } from "@/common/components/Auth";
+import { Suspense } from "react";
+import { useRouter } from "next/navigation";
+
+export default function ConfirmSignUp() {
+  const router = useRouter();
+  const currentURL = new URL(window.location.href);
+  const confirmationUrl = currentURL.searchParams.get("confirmation_url");
+  if (!confirmationUrl) {
+    router.push("/account/auth/signup");
+    return;
+  }
+  return (
+    <>
+      <section className="flex h-full flex-shrink-0 items-center justify-center py-16">
+        <AuthCard title="Thank you for your registration!">
+          <Suspense fallback={<div>Loading...</div>}>
+            <ConfirmSignUpNote confirmationUrl={confirmationUrl} />
+          </Suspense>
+        </AuthCard>
+      </section>
+    </>
+  );
+}

--- a/src/app/account/auth/confirm-signup/page.tsx
+++ b/src/app/account/auth/confirm-signup/page.tsx
@@ -1,13 +1,22 @@
 import { Suspense } from "react";
 import { AuthCard, ConfirmSignUpNote } from "@/common/components/Auth";
+import { notFound } from "next/navigation";
 
-export default function ConfirmSignUp() {
+export default function ConfirmSignUp({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const confirmationUrl = searchParams["confirmation_url"];
+  if (!confirmationUrl || typeof confirmationUrl !== "string") {
+    notFound();
+  }
   return (
     <>
       <section className="flex h-full flex-shrink-0 items-center justify-center py-16">
         <AuthCard title="Thank you for your registration!">
           <Suspense fallback={<div>Loading...</div>}>
-            <ConfirmSignUpNote />
+            <ConfirmSignUpNote confirmationUrl={confirmationUrl} />
           </Suspense>
         </AuthCard>
       </section>

--- a/src/app/account/auth/confirm-signup/page.tsx
+++ b/src/app/account/auth/confirm-signup/page.tsx
@@ -1,32 +1,13 @@
-"use client";
-
-import { useState, useEffect, Suspense } from "react";
+import { Suspense } from "react";
 import { AuthCard, ConfirmSignUpNote } from "@/common/components/Auth";
-import { useRouter } from "next/navigation";
 
 export default function ConfirmSignUp() {
-  const router = useRouter();
-  const [confirmationUrl, setConfirmationUrl] = useState("");
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const currentURL = new URL(window.location.href);
-      const urlParam = currentURL.searchParams.get("confirmation_url");
-      if (urlParam) {
-        setConfirmationUrl(urlParam);
-      } else {
-        router.push("/account/auth/signup");
-      }
-    }
-  }, [router, confirmationUrl]);
-  if (!confirmationUrl) {
-    return;
-  }
   return (
     <>
       <section className="flex h-full flex-shrink-0 items-center justify-center py-16">
         <AuthCard title="Thank you for your registration!">
           <Suspense fallback={<div>Loading...</div>}>
-            <ConfirmSignUpNote confirmationUrl={confirmationUrl} />
+            <ConfirmSignUpNote />
           </Suspense>
         </AuthCard>
       </section>

--- a/src/app/account/auth/confirm-signup/page.tsx
+++ b/src/app/account/auth/confirm-signup/page.tsx
@@ -1,15 +1,24 @@
 "use client";
 
+import { useState, useEffect, Suspense } from "react";
 import { AuthCard, ConfirmSignUpNote } from "@/common/components/Auth";
-import { Suspense } from "react";
 import { useRouter } from "next/navigation";
 
 export default function ConfirmSignUp() {
   const router = useRouter();
-  const currentURL = new URL(window.location.href);
-  const confirmationUrl = currentURL.searchParams.get("confirmation_url");
+  const [confirmationUrl, setConfirmationUrl] = useState("");
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const currentURL = new URL(window.location.href);
+      const urlParam = currentURL.searchParams.get("confirmation_url");
+      if (urlParam) {
+        setConfirmationUrl(urlParam);
+      } else {
+        router.push("/account/auth/signup");
+      }
+    }
+  }, [router, confirmationUrl]);
   if (!confirmationUrl) {
-    router.push("/account/auth/signup");
     return;
   }
   return (

--- a/src/app/account/auth/verify/page.tsx
+++ b/src/app/account/auth/verify/page.tsx
@@ -1,78 +1,24 @@
 "use client";
 
-import { useEffect, useState, type FormEvent, Suspense } from "react";
+import { Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-
-import { AuthCard } from "@/common/components/Auth";
-import { Button } from "@/common/components/Button";
-
-const emailResendBufferSeconds = 60;
-
-function VerifyConfirmationNote() {
-  const searchParams = useSearchParams();
-  const email = searchParams.get("email");
-  return (
-    <>
-      <div className="flex flex-col gap-6 text-text-em-high">
-        <p>
-          You’re almost there! We’ve sent a verification email to
-          <br />
-          <b>{email}</b>.
-        </p>
-        <p>
-          Please click on the link in that email to verify your account within
-          <br />
-          20 minutes.
-        </p>
-      </div>
-    </>
-  );
-}
+import { AuthCard, VerificationEmailForm } from "@/common/components/Auth";
+import { useRouter } from "next/navigation";
 
 export default function Verify() {
-  const [secondsToResendEmail, setSecondsToResendEmail] = useState(
-    emailResendBufferSeconds,
-  );
-  const [formSubmittedLoading, setFormSubmittedLoading] = useState(false);
-  useEffect(() => {
-    setTimeout(() => {
-      secondsToResendEmail > 0 &&
-        setSecondsToResendEmail(secondsToResendEmail - 1);
-    }, 1000);
-  }, [secondsToResendEmail]);
-
-  const handleResendEmailOtp = async (e: FormEvent) => {
-    e.preventDefault();
-    setFormSubmittedLoading(true);
-
-    // TODO: replace with resend otp logic
-    await new Promise((r) => setTimeout(r, 2000));
-    alert("Email sent!");
-
-    setSecondsToResendEmail(emailResendBufferSeconds);
-    setFormSubmittedLoading(false);
-  };
-
-  const buttonText = () => {
-    if (formSubmittedLoading) return "Resending email...";
-    if (secondsToResendEmail > 0)
-      return `Resend email in ${secondsToResendEmail}s`;
-    return "Resend email";
-  };
-
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email");
+  if (!email) {
+    router.push("/account/auth/signup");
+    return;
+  }
   return (
     <>
       <section className="flex h-full flex-shrink-0 items-center justify-center py-16">
-        <AuthCard title="We emailed you a link" onSubmit={handleResendEmailOtp}>
+        <AuthCard title="We emailed you a link">
           <Suspense fallback={<div>Loading...</div>}>
-            <VerifyConfirmationNote />
-            <Button
-              variant="tertiary"
-              type="submit"
-              disabled={formSubmittedLoading || secondsToResendEmail > 0}
-            >
-              {buttonText()}
-            </Button>
+            <VerificationEmailForm email={email} />
           </Suspense>
         </AuthCard>
       </section>

--- a/src/app/account/auth/verify/page.tsx
+++ b/src/app/account/auth/verify/page.tsx
@@ -1,24 +1,15 @@
 "use client";
 
 import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
 import { AuthCard, VerificationEmailForm } from "@/common/components/Auth";
-import { useRouter } from "next/navigation";
 
 export default function Verify() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const email = searchParams.get("email");
-  if (!email) {
-    router.push("/account/auth/signup");
-    return;
-  }
   return (
     <>
       <section className="flex h-full flex-shrink-0 items-center justify-center py-16">
         <AuthCard title="We emailed you a link">
           <Suspense fallback={<div>Loading...</div>}>
-            <VerificationEmailForm email={email} />
+            <VerificationEmailForm />
           </Suspense>
         </AuthCard>
       </section>

--- a/src/common/components/Auth/ConfirmSignUpNote.tsx
+++ b/src/common/components/Auth/ConfirmSignUpNote.tsx
@@ -1,0 +1,18 @@
+import { Button } from "@/common/components/Button";
+
+export const ConfirmSignUpNote = ({
+  confirmationUrl,
+}: {
+  confirmationUrl: string;
+}) => {
+  return (
+    <div className="flex flex-col gap-6 pb-3 text-text-em-high">
+      <p>Please click on the button below to complete your sign up process.</p>
+      <a href={confirmationUrl}>
+        <Button variant="tertiary" disabled={!confirmationUrl}>
+          Confirm Sign Up
+        </Button>
+      </a>
+    </div>
+  );
+};

--- a/src/common/components/Auth/ConfirmSignUpNote.tsx
+++ b/src/common/components/Auth/ConfirmSignUpNote.tsx
@@ -1,14 +1,10 @@
-"use client";
-
 import { Button } from "@/common/components/Button";
-import { useSearchParams, notFound } from "next/navigation";
 
-export const ConfirmSignUpNote = () => {
-  const searchParams = useSearchParams();
-  const confirmationUrl = searchParams.get("confirmation_url");
-  if (!confirmationUrl) {
-    notFound();
-  }
+export const ConfirmSignUpNote = ({
+  confirmationUrl,
+}: {
+  confirmationUrl: string;
+}) => {
   return (
     <div className="flex flex-col gap-6 pb-3 text-text-em-high">
       <p>Please click on the button below to complete your sign up process.</p>

--- a/src/common/components/Auth/ConfirmSignUpNote.tsx
+++ b/src/common/components/Auth/ConfirmSignUpNote.tsx
@@ -1,10 +1,14 @@
-import { Button } from "@/common/components/Button";
+"use client";
 
-export const ConfirmSignUpNote = ({
-  confirmationUrl,
-}: {
-  confirmationUrl: string;
-}) => {
+import { Button } from "@/common/components/Button";
+import { useSearchParams, notFound } from "next/navigation";
+
+export const ConfirmSignUpNote = () => {
+  const searchParams = useSearchParams();
+  const confirmationUrl = searchParams.get("confirmation_url");
+  if (!confirmationUrl) {
+    notFound();
+  }
   return (
     <div className="flex flex-col gap-6 pb-3 text-text-em-high">
       <p>Please click on the button below to complete your sign up process.</p>

--- a/src/common/components/Auth/VerificationEmailForm.tsx
+++ b/src/common/components/Auth/VerificationEmailForm.tsx
@@ -58,17 +58,15 @@ export const VerificationEmailForm = ({ email }: { email: string }) => {
   };
 
   return (
-    <>
-      <form onSubmit={handleResendEmailOtp}>
-        <EmailConfirmationNote email={email} />
-        <Button
-          variant="tertiary"
-          type="submit"
-          disabled={formSubmittedLoading || secondsToResendEmail > 0}
-        >
-          {buttonText()}
-        </Button>
-      </form>
-    </>
+    <form onSubmit={handleResendEmailOtp}>
+      <EmailConfirmationNote email={email} />
+      <Button
+        variant="tertiary"
+        type="submit"
+        disabled={formSubmittedLoading || secondsToResendEmail > 0}
+      >
+        {buttonText()}
+      </Button>
+    </form>
   );
 };

--- a/src/common/components/Auth/VerificationEmailForm.tsx
+++ b/src/common/components/Auth/VerificationEmailForm.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/common/components/Button";
 import { resendEmail, ResendType } from "@/server/supabase";
 import { useSearchParams, notFound } from "next/navigation";
 
-const emailResendBufferSeconds = 60;
+const EMAIL_RESEND_BUFFER_SECONDS = 60;
 
 function EmailConfirmationNote({ email }: { email: string }) {
   return (
@@ -28,7 +28,7 @@ function EmailConfirmationNote({ email }: { email: string }) {
 
 export const VerificationEmailForm = () => {
   const [secondsToResendEmail, setSecondsToResendEmail] = useState(
-    emailResendBufferSeconds,
+    EMAIL_RESEND_BUFFER_SECONDS,
   );
   const [formSubmittedLoading, setFormSubmittedLoading] = useState(false);
   useEffect(() => {
@@ -51,7 +51,7 @@ export const VerificationEmailForm = () => {
     } else {
       alert("Email sent! Please check your inbox");
     }
-    setSecondsToResendEmail(emailResendBufferSeconds);
+    setSecondsToResendEmail(EMAIL_RESEND_BUFFER_SECONDS);
     setFormSubmittedLoading(false);
   };
 

--- a/src/common/components/Auth/VerificationEmailForm.tsx
+++ b/src/common/components/Auth/VerificationEmailForm.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { Button } from "@/common/components/Button";
 import { resendEmail, ResendType } from "@/server/supabase";
+import { useSearchParams, useRouter } from "next/navigation";
 
 const emailResendBufferSeconds = 60;
 
@@ -25,7 +26,8 @@ function EmailConfirmationNote({ email }: { email: string }) {
   );
 }
 
-export const VerificationEmailForm = ({ email }: { email: string }) => {
+export const VerificationEmailForm = () => {
+  const router = useRouter();
   const [secondsToResendEmail, setSecondsToResendEmail] = useState(
     emailResendBufferSeconds,
   );
@@ -36,7 +38,12 @@ export const VerificationEmailForm = ({ email }: { email: string }) => {
         setSecondsToResendEmail(secondsToResendEmail - 1);
     }, 1000);
   }, [secondsToResendEmail]);
-
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email");
+  if (!email) {
+    router.push("/account/auth/signup");
+    return;
+  }
   const handleResendEmailOtp = async (e: FormEvent) => {
     e.preventDefault();
     setFormSubmittedLoading(true);

--- a/src/common/components/Auth/VerificationEmailForm.tsx
+++ b/src/common/components/Auth/VerificationEmailForm.tsx
@@ -45,7 +45,7 @@ export const VerificationEmailForm = () => {
   const handleResendEmailOtp = async (e: FormEvent) => {
     e.preventDefault();
     setFormSubmittedLoading(true);
-    const res = await resendEmail(email, ResendType.Signup);
+    const res = await resendEmail(email, ResendType.SIGNUP);
     if (res.error) {
       alert(res.error.message);
     } else {

--- a/src/common/components/Auth/VerificationEmailForm.tsx
+++ b/src/common/components/Auth/VerificationEmailForm.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { Button } from "@/common/components/Button";
+import { resendEmail, ResendType } from "@/server/supabase";
+
+const emailResendBufferSeconds = 60;
+
+function EmailConfirmationNote({ email }: { email: string }) {
+  return (
+    <>
+      <div className="flex flex-col gap-6 pb-3 text-text-em-high">
+        <p>
+          You’re almost there! We’ve sent a verification email to
+          <br />
+          <b>{email}</b>.
+        </p>
+        <p>
+          Please click on the link in that email to verify your account within
+          <br />
+          20 minutes.
+        </p>
+      </div>
+    </>
+  );
+}
+
+export const VerificationEmailForm = ({ email }: { email: string }) => {
+  const [secondsToResendEmail, setSecondsToResendEmail] = useState(
+    emailResendBufferSeconds,
+  );
+  const [formSubmittedLoading, setFormSubmittedLoading] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      secondsToResendEmail > 0 &&
+        setSecondsToResendEmail(secondsToResendEmail - 1);
+    }, 1000);
+  }, [secondsToResendEmail]);
+
+  const handleResendEmailOtp = async (e: FormEvent) => {
+    e.preventDefault();
+    setFormSubmittedLoading(true);
+    const res = await resendEmail(email, ResendType.Signup);
+    if (res.error) {
+      alert(res.error.message);
+    } else {
+      alert("Email sent! Please check your inbox");
+    }
+    setSecondsToResendEmail(emailResendBufferSeconds);
+    setFormSubmittedLoading(false);
+  };
+
+  const buttonText = () => {
+    if (formSubmittedLoading) return "Resending email...";
+    if (secondsToResendEmail > 0)
+      return `Resend email in ${secondsToResendEmail}s`;
+    return "Resend email";
+  };
+
+  return (
+    <>
+      <form onSubmit={handleResendEmailOtp}>
+        <EmailConfirmationNote email={email} />
+        <Button
+          variant="tertiary"
+          type="submit"
+          disabled={formSubmittedLoading || secondsToResendEmail > 0}
+        >
+          {buttonText()}
+        </Button>
+      </form>
+    </>
+  );
+};

--- a/src/common/components/Auth/VerificationEmailForm.tsx
+++ b/src/common/components/Auth/VerificationEmailForm.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 import { Button } from "@/common/components/Button";
 import { resendEmail, ResendType } from "@/server/supabase";
-import { useSearchParams, useRouter } from "next/navigation";
+import { useSearchParams, notFound } from "next/navigation";
 
 const emailResendBufferSeconds = 60;
 
@@ -27,7 +27,6 @@ function EmailConfirmationNote({ email }: { email: string }) {
 }
 
 export const VerificationEmailForm = () => {
-  const router = useRouter();
   const [secondsToResendEmail, setSecondsToResendEmail] = useState(
     emailResendBufferSeconds,
   );
@@ -41,8 +40,7 @@ export const VerificationEmailForm = () => {
   const searchParams = useSearchParams();
   const email = searchParams.get("email");
   if (!email) {
-    router.push("/account/auth/signup");
-    return;
+    notFound();
   }
   const handleResendEmailOtp = async (e: FormEvent) => {
     e.preventDefault();

--- a/src/common/components/Auth/index.ts
+++ b/src/common/components/Auth/index.ts
@@ -3,3 +3,4 @@ export * from "./LoginForm";
 export * from "./SignupForm";
 export * from "./ResetPasswordForm";
 export * from "./VerificationEmailForm";
+export * from "./ConfirmSignUpNote";

--- a/src/common/components/Auth/index.ts
+++ b/src/common/components/Auth/index.ts
@@ -2,3 +2,4 @@ export * from "./AuthCard";
 export * from "./LoginForm";
 export * from "./SignupForm";
 export * from "./ResetPasswordForm";
+export * from "./VerificationEmailForm";

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,6 @@ export const config = {
      *
      * @see https://nextjs.org/docs/app/building-your-application/routing/middleware#matching-paths
      */
-    "/((?!api|_next/static|_next/image|favicon.ico|account/auth).*)",
+    "/((?!api|_next/static|_next/image|favicon.ico|account/auth|not-found).*)",
   ],
 };

--- a/src/server/supabase.ts
+++ b/src/server/supabase.ts
@@ -2,8 +2,8 @@ import { createClient } from "@supabase/supabase-js";
 import { env } from "@/env.mjs";
 
 export enum ResendType {
-  Signup = "signup",
-  EmailChange = "email_change",
+  SIGNUP = "signup",
+  EMAIL_CHANGE = "email_change",
 }
 
 export const supabase = createClient(

--- a/src/server/supabase.ts
+++ b/src/server/supabase.ts
@@ -1,9 +1,14 @@
 import { createClient } from "@supabase/supabase-js";
 import { env } from "@/env.mjs";
 
+export enum ResendType {
+  Signup = "signup",
+  EmailChange = "email_change",
+}
+
 export const supabase = createClient(
   env.NEXT_PUBLIC_SUPABASE_URL,
-  env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
 );
 
 export const signInWithEmail = async (email: string, password: string) => {
@@ -18,6 +23,14 @@ export const signUpWithEmail = async (email: string, password: string) => {
   const { data, error } = await supabase.auth.signUp({
     email: email,
     password: password,
+  });
+  return { data, error };
+};
+
+export const resendEmail = async (email: string, type: ResendType) => {
+  const { data, error } = await supabase.auth.resend({
+    type: type,
+    email: email,
   });
   return { data, error };
 };


### PR DESCRIPTION
Closes #12 

## Changes
- add resend email feature
- add custom `confirm sign up` page where user can click on a button to verify their email
- redirect user to 404 page for any improper access to `verify` and `confirm-signup` page

## Implementation
1. Certain email providers may prefetch URL links from incoming emails as part of a security feature. In this case, the confirmation url link sent by Supabase to the use will be consumed instantly, which leads to a "Token has expired or is invalid" error. To mitigate this, we have chosen to create a custom email link to redirect the user to a custom  `confirm sign up page`. This implementation will require the user to actually clicks on the `confirm sign up` button to verify their identities.
Refer [supabase doc](https://supabase.com/docs/guides/auth/auth-email-templates) for more details
2. For error handling, we are now redirecting user to `not-found` page if user tries to access the page by manipulating the urls directly
3. For resend email function in supabase, I have enabled the function to accept `ResendType` as to make the function more generic (so that in the case where we need it for `email_change` in the future, we can reuse the function)

## Testing
To set up the project locally for testing, follow the following steps:
1. Install dependencies
`yarn install`
3. Run the development server
`yarn dev`
4. Head over to user sign up page
5. Fill in valid school emails and password
6. If account creation is successful, you should be redirected to email verification page
7. Check your inbox for the supabase email verification link
8. Once you click on the link, you should be redirected to sign up confirmation page
9. Click on the `Confirm Sign Up` button and you should be redirected to log in page
10. Log in using the credentials used in step 5, and click on log in button
11. You should be able to see AfterClass' homepage successfully


## Preview