### PR TITLE
feat(ui): `TagGroup` component

### DIFF
--- a/src/common/components/Tag/Tag.stories.tsx
+++ b/src/common/components/Tag/Tag.stories.tsx
@@ -30,3 +30,11 @@ export const Active: Story = {
     active: true,
   },
 };
+
+export const Clickable: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    clickable: true,
+  },
+};

--- a/src/common/components/Tag/Tag.theme.ts
+++ b/src/common/components/Tag/Tag.theme.ts
@@ -18,8 +18,6 @@ export const tagTheme = tv(
         "border-solid",
         "border-border-default",
         "transition-color",
-        "duration-300",
-        "ease-in-out",
         "bg-transparent",
       ],
       icon: [],
@@ -34,6 +32,11 @@ export const tagTheme = tv(
           ],
         },
       },
+      clickable: {
+        true: {
+          tag: ["cursor-pointer", "hover:bg-element-secondary"],
+        },
+      },
       size: {
         sm: {
           icon: ["h-3", "w-3"],
@@ -43,6 +46,15 @@ export const tagTheme = tv(
         },
       },
     },
+    compoundVariants: [
+      {
+        active: true,
+        clickable: true,
+        class: {
+          tag: ["hover:text-text-on-secondary"],
+        },
+      },
+    ],
   },
   { responsiveVariants: true },
 );

--- a/src/common/components/Tag/Tag.tsx
+++ b/src/common/components/Tag/Tag.tsx
@@ -4,6 +4,7 @@ import {
   cloneElement,
   isValidElement,
   useCallback,
+  useState,
   type ComponentPropsWithoutRef,
   type HTMLProps,
   type ReactElement,
@@ -21,10 +22,16 @@ export const Tag = ({
   contentRight,
   children,
   active = false,
+  clickable = false,
   size = "md",
+  className,
+  ...props
 }: TagProps) => {
+  const [isActive, setIsActive] = useState(active);
+
   const { tag, icon: iconTheme } = tagTheme({
-    active,
+    active: isActive,
+    clickable,
     size,
   });
   const StyledIcon = useCallback(
@@ -46,7 +53,11 @@ export const Tag = ({
     [size, iconTheme],
   );
   return (
-    <div className={tag()}>
+    <div
+      className={tag({ className })}
+      onClick={clickable ? () => setIsActive(!isActive) : undefined}
+      {...props}
+    >
       <StyledIcon icon={contentLeft} />
       {children && <span>{children}</span>}
       <StyledIcon icon={contentRight} />

--- a/src/common/components/TagGroup/TagGroup.stories.tsx
+++ b/src/common/components/TagGroup/TagGroup.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { TagGroup } from "./TagGroup";
+import { Field } from "@/common/components/Field";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Common/TagGroup",
+  component: TagGroup,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  args: {
+    items: [
+      {
+        label: "Engaging",
+        value: "ENGAGING",
+      },
+      {
+        label: "Knowledgeable",
+        value: "KNOWLEDGEABLE",
+      },
+      {
+        label: "Fair grading",
+        value: "FAIR_GRADING",
+      },
+      {
+        label: "Effective teaching",
+        value: "EFFECTIVE_TEACHING",
+      },
+      {
+        label: "Manageable workload",
+        value: "MANAGEABLE_WORKLOAD",
+      },
+    ],
+  },
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+} satisfies Meta<typeof TagGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+
+const formSchema = z.object({
+  tags: z.array(z.string()),
+});
+type FormInputsSchema = z.infer<typeof formSchema>;
+
+export const AsFormInput: Story = {
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+      },
+    },
+  },
+  render: (args) => {
+    const { register, watch } = useForm<FormInputsSchema>({
+      resolver: zodResolver(formSchema),
+    });
+    return (
+      <div>
+        <form>
+          <Field label="Tags *" isError={false}>
+            <TagGroup {...args} {...register("tags")} />
+          </Field>
+        </form>
+        <hr className="my-4" />
+        <pre>{JSON.stringify(watch())}</pre>
+      </div>
+    );
+  },
+};

--- a/src/common/components/TagGroup/TagGroup.theme.ts
+++ b/src/common/components/TagGroup/TagGroup.theme.ts
@@ -1,0 +1,21 @@
+import { type VariantProps, tv } from "tailwind-variants";
+
+export type TagGroupVariants = VariantProps<typeof tagGroupTheme>;
+
+export const tagGroupTheme = tv(
+  {
+    slots: {
+      wrapper: [
+        "flex",
+        "flex-wrap",
+        "content-start",
+        "items-start",
+        "gap-3",
+        "self-stretch",
+      ],
+      input: ["hidden"],
+      tag: ["select-none"],
+    },
+  },
+  { responsiveVariants: true },
+);

--- a/src/common/components/TagGroup/TagGroup.tsx
+++ b/src/common/components/TagGroup/TagGroup.tsx
@@ -1,0 +1,40 @@
+import { Fragment, forwardRef, type ComponentPropsWithoutRef } from "react";
+
+import { Tag } from "@/common/components/Tag";
+import { tagGroupTheme } from "./TagGroup.theme";
+
+const randomHash = (Math.random() + 1).toString(36).substring(7);
+
+export type TagGroupProps = ComponentPropsWithoutRef<"input"> & {
+  items: { label: string; value: string }[];
+};
+
+export const TagGroup = forwardRef<HTMLInputElement, TagGroupProps>(
+  ({ items, ...props }, ref) => {
+    const { wrapper, input, tag } = tagGroupTheme();
+    return (
+      <div className={wrapper()}>
+        {items.map(({ label, value }, i) => {
+          const key = `${randomHash}_tag-${i}`;
+          return (
+            <Fragment key={key}>
+              <label>
+                <input
+                  className={input()}
+                  type="checkbox"
+                  value={value}
+                  ref={ref}
+                  {...props}
+                />
+                <Tag clickable={true} className={tag()}>
+                  {label}
+                </Tag>
+              </label>
+            </Fragment>
+          );
+        })}
+      </div>
+    );
+  },
+);
+TagGroup.displayName = "TagGroup";

--- a/src/common/components/TagGroup/index.ts
+++ b/src/common/components/TagGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./TagGroup";


### PR DESCRIPTION
## changes

- \+ `TagGroup` Component

## implementation

- updated `<Tag/>` with a new `clickable` variant
- make `<Tag/>` as checkbox group for form input

## testing

- [Chromatic build review](https://www.chromatic.com/build?appId=65e66a97ccf98da794749891&number=63)
- [Storybooks on Chromatic](https://65e66a97ccf98da794749891-rkogcezuht.chromatic.com/)

## preview

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/bf2ef214-e890-4afc-a523-b3be639624cc)
![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/86775f0c-4284-4fc9-b9a1-548f6e216a0f)

### Hover

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/cba87341-876c-45ce-9214-66d793c8b2c7)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/85744015-7918-4298-8d9c-9f7f11706d56)

### Active + Hover

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/503b5e15-e9c3-4f06-9daa-043ded0315b5)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/7ecd7c5d-3e88-4c58-b794-307fc17946a1)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/32901d21-0835-422a-bc1f-49afe7e853c2)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/1b0bf9dc-8879-4e2b-a2d1-d3fb4e9fd54c)

### Active

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/2fadd453-ad6f-4b9f-a313-8461d5924646)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/9df2d966-f14b-472b-b966-d65f307e85db)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/cbcbe422-1dd6-4624-a284-489f4d42af05)

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/da9714cd-3c0f-4380-993e-b3a18bf3c96e)
