### PR TITLE
fix: explicit redirect to login instead of root

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -32,6 +32,20 @@ export const env = createEnv({
    */
   client: {
     // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+    NEXT_PUBLIC_SITE_URL: z
+      .optional(z.string())
+      .transform((str) => {
+        let url =
+          str ??
+          process.env.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+          "http://localhost:3000/";
+        // Make sure to include `https://` when not localhost.
+        url = url.includes("http") ? url : `https://${url}`;
+        // Make sure to include a trailing `/`.
+        url = url.charAt(url.length - 1) === "/" ? url : `${url}/`;
+        return url;
+      })
+      .pipe(z.string().url()),
     NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
     NEXT_PUBLIC_SUPABASE_URL: z.string(),
     NEXT_PUBLIC_SUPPORTED_SCH_DOMAINS: z
@@ -66,6 +80,7 @@ export const env = createEnv({
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL,
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     NEXT_PUBLIC_SUPPORTED_SCH_DOMAINS:

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -37,12 +37,13 @@ export const env = createEnv({
       .transform((str) => {
         let url =
           str ??
-          process.env.NEXT_PUBLIC_VERCEL_URL ?? // Automatically set by Vercel.
+          // Automatically set by Vercel as system environment variable
+          // NEXT_PUBLIC_VERCEL_URL doesn't include `https`
+          // https://vercel.com/docs/projects/environment-variables/system-environment-variables
+          process.env.NEXT_PUBLIC_VERCEL_URL ??
           "http://localhost:3000/";
-        // Make sure to include `https://` when not localhost.
-        url = url.includes("http") ? url : `https://${url}`;
-        // Make sure to include a trailing `/`.
-        url = url.charAt(url.length - 1) === "/" ? url : `${url}/`;
+        // Make sure to include `https://` when using NEXT_PUBLIC_VERCEL_URL
+        url = url.startsWith("http") ? url : `https://${url}`;
         return url;
       })
       .pipe(z.string().url()),

--- a/src/server/supabase.ts
+++ b/src/server/supabase.ts
@@ -23,6 +23,9 @@ export const signUpWithEmail = async (email: string, password: string) => {
   const { data, error } = await supabase.auth.signUp({
     email: email,
     password: password,
+    options: {
+      emailRedirectTo: `${env.NEXT_PUBLIC_SITE_URL}/account/auth/login`,
+    },
   });
   return { data, error };
 };


### PR DESCRIPTION
## Context

Current signup flow redirects user to the root `/`

Ever since change was made to let root `/` exempted from auth middleware at bced73beaba553bcd66df71d46b6b228ccfe4573, the redirect now pauses at root with the user not being signed in, requiring 1 extra click to be directed to login which is poor UX

## Changes

Add `emailRedirectTo` option when `signUp` is called with email & password credentials, allowing redirect to be explicitly to `/account/auth/login` so the user will login after confirming their email

### New Flow

1. user click sign up
2. user input email + pwd & cfm pwd
3. user redirects to `/account/auth/verify` page to let user know that email is sent
4. user receives email
5. user clicks link on email & gets directed to `/account/auth/confirm-signup` page with a button that calls supabase api on click + a redirect url
6. user clicks button & gets redirected to `/account/auth/login`
7. user logins with credentials
8. end of flow
