### PR TITLE
feat(UI): Course Page Info Card

### DIFF
--- a/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/common/components/Skeleton";
+import { InformationCard } from "@/modules/reviews/InformationSection/InformationCard";
+
+export default function Loading() {
+  return (
+    <div className="w-full">
+      <InformationCard>
+        <Skeleton className="h-[60px] w-full" />
+      </InformationCard>
+    </div>
+  );
+}

--- a/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
@@ -1,13 +1,10 @@
-import { Skeleton } from "@/common/components/Skeleton";
 import { InformationCard } from "@/modules/reviews/InformationSection/InformationCard";
 
 export default function Loading() {
   return (
-    <div className="flex gap-6">
+    <div className="flex w-full gap-6">
       <div className="w-2/3">
-        <InformationCard>
-          <Skeleton className="h-[60px] w-full" />
-        </InformationCard>
+        <InformationCard.Skeleton />
       </div>
       <div className="w-1/3">TODO: course detail</div>
     </div>

--- a/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
@@ -3,10 +3,13 @@ import { InformationCard } from "@/modules/reviews/InformationSection/Informatio
 
 export default function Loading() {
   return (
-    <div className="w-full">
-      <InformationCard>
-        <Skeleton className="h-[60px] w-full" />
-      </InformationCard>
+    <div className="flex gap-6">
+      <div className="w-2/3">
+        <InformationCard>
+          <Skeleton className="h-[60px] w-full" />
+        </InformationCard>
+      </div>
+      <div className="w-1/3">TODO: course detail</div>
     </div>
   );
 }

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -9,7 +9,7 @@ export default async function CourseInfo({
   params: { code: string };
 }) {
   const session = await getServerAuthSession();
-  const course = await api.courses.getByCourseCode({ code: params.code });
+  const course = await api.courses.getByCourseCode({ code: params.code.toUpperCase() });
   if (!course) {
     return notFound();
   }

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -1,0 +1,19 @@
+import { api } from "@/common/tools/trpc/server";
+import { notFound } from "next/navigation";
+import { InformationCard } from "@/modules/reviews/InformationSection/InformationCard";
+import { getServerAuthSession } from "@/server/auth";
+
+export default async function CourseInfo({
+  params,
+}: {
+  params: { code: string };
+}) {
+  const session = await getServerAuthSession();
+  const course = await api.courses.getByCourseCode({ code: params.code });
+  if (!course) {
+    return notFound();
+  }
+  return (
+    <InformationCard isLocked={!session}>{course.description}</InformationCard>
+  );
+}

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -18,8 +18,15 @@ export default async function CourseInfo({
   return (
     <div className="flex w-full gap-6">
       <div className="w-2/3">
-        <InformationCard course={course} isLocked={!session}>
-          {course.description}
+        <InformationCard courseDesc={course.description}>
+          {!session ? (
+            <InformationCard.LoginButton />
+          ) : (
+            <InformationCard.Modal
+              courseName={course.name}
+              courseDesc={course.description}
+            />
+          )}
         </InformationCard>
       </div>
       <div className="w-1/3">TODO: course detail</div>

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -9,14 +9,16 @@ export default async function CourseInfo({
   params: { code: string };
 }) {
   const session = await getServerAuthSession();
-  const course = await api.courses.getByCourseCode({ code: params.code.toUpperCase() });
+  const course = await api.courses.getByCourseCode({
+    code: params.code.toUpperCase(),
+  });
   if (!course) {
     return notFound();
   }
   return (
-    <div className="flex gap-6">
+    <div className="flex w-full gap-6">
       <div className="w-2/3">
-        <InformationCard isLocked={!session}>
+        <InformationCard course={course} isLocked={!session}>
           {course.description}
         </InformationCard>
       </div>

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -14,6 +14,13 @@ export default async function CourseInfo({
     return notFound();
   }
   return (
-    <InformationCard isLocked={!session}>{course.description}</InformationCard>
+    <div className="flex gap-6">
+      <div className="w-2/3">
+        <InformationCard isLocked={!session}>
+          {course.description}
+        </InformationCard>
+      </div>
+      <div className="w-1/3">TODO: course detail</div>
+    </div>
   );
 }

--- a/src/app/(school)/(reviews)/@information/default.tsx
+++ b/src/app/(school)/(reviews)/@information/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null;
+}

--- a/src/app/(school)/(reviews)/@information/page.tsx
+++ b/src/app/(school)/(reviews)/@information/page.tsx
@@ -1,0 +1,5 @@
+import { AnnouncementBanner } from "@/modules/home/AnnouncementBanner";
+
+export default function HomeHeader() {
+  return <AnnouncementBanner />;
+}

--- a/src/app/(school)/(reviews)/@information/page.tsx
+++ b/src/app/(school)/(reviews)/@information/page.tsx
@@ -1,5 +1,4 @@
-import { AnnouncementBanner } from "@/modules/home/AnnouncementBanner";
-
-export default function HomeHeader() {
-  return <AnnouncementBanner />;
+// no "information and detail" section in the home page
+export default function NotImplemented() {
+  return null;
 }

--- a/src/app/(school)/(reviews)/layout.tsx
+++ b/src/app/(school)/(reviews)/layout.tsx
@@ -7,16 +7,19 @@ export default function ReviewLayout({
   header,
   filter,
   rating,
+  information,
 }: {
   children: ReactNode;
   header: ReactNode;
   filter: ReactNode;
   rating: ReactNode;
+  information: ReactNode;
 }) {
   return (
     <section className="relative flex h-full flex-col items-center space-y-6 overflow-y-auto overflow-x-hidden">
       {header}
       {rating}
+      {information}
       {filter}
       <div className="flex w-full gap-10">
         {children}

--- a/src/common/components/CustomIcon/ClipboardIcon.tsx
+++ b/src/common/components/CustomIcon/ClipboardIcon.tsx
@@ -1,0 +1,31 @@
+import { CustomIcon, type CustomIconProps } from "./CustomIcon";
+
+export const ClipboardIcon = (props: CustomIconProps) => {
+  return (
+    <CustomIcon
+      width="36"
+      height="36"
+      viewBox="0 0 36 36"
+      fill="none"
+      {...props}
+    >
+      <path
+        fill="#5039D4"
+        d="M32 34a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h24a2 2 0 0 1 2 2z"
+      />
+      <path
+        fill="#fff"
+        d="M29 32a1 1 0 0 1-1 1H8a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1h20a1 1 0 0 1 1 1z"
+      />
+      <path
+        fill="#ccd6dd"
+        d="M25 3h-4a3 3 0 1 0-6 0h-4a2 2 0 0 0-2 2v5h18V5a2 2 0 0 0-2-2"
+      />
+      <circle cx="18" cy="3" r="2" fill="#292f33" />
+      <path
+        fill="#99aab5"
+        d="M20 14a1 1 0 0 1-1 1h-9a1 1 0 0 1 0-2h9a1 1 0 0 1 1 1m7 4a1 1 0 0 1-1 1H10a1 1 0 0 1 0-2h16a1 1 0 0 1 1 1m0 4a1 1 0 0 1-1 1H10a1 1 0 1 1 0-2h16a1 1 0 0 1 1 1m0 4a1 1 0 0 1-1 1H10a1 1 0 1 1 0-2h16a1 1 0 0 1 1 1m0 4a1 1 0 0 1-1 1h-9a1 1 0 1 1 0-2h9a1 1 0 0 1 1 1"
+      />
+    </CustomIcon>
+  );
+};

--- a/src/common/components/CustomIcon/index.ts
+++ b/src/common/components/CustomIcon/index.ts
@@ -34,3 +34,4 @@ export * from "./SchoolIcon";
 export * from "./ShareIcon";
 export * from "./ChartLineIcon";
 export * from "./PenIcon";
+export * from "./ClipboardIcon";

--- a/src/modules/reviews/InformationSection/InformationCard/InformationCard.theme.ts
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCard.theme.ts
@@ -1,0 +1,32 @@
+import { type VariantProps, tv } from "tailwind-variants";
+
+export type InformationCardVariants = VariantProps<typeof informationCardTheme>;
+
+export const informationCardTheme = tv(
+  {
+    slots: {
+      wrapper: [
+        "w-full",
+        "flex",
+        "flex-col",
+        "bg-surface-base",
+        "rounded-2xl",
+        "gap-5",
+        "p-6",
+        "text-base",
+      ],
+      header: [
+        "flex",
+        "items-center",
+        "gap-4",
+        "text-2xl",
+        "font-semibold",
+        "text-text-em-high",
+      ],
+      icon: ["h-6", "w-6"],
+      content: ["flex", "flex-col", "gap-2"],
+      description: ["line-clamp-3", "text-text-em-high"],
+    },
+  },
+  { responsiveVariants: true },
+);

--- a/src/modules/reviews/InformationSection/InformationCard/InformationCard.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCard.tsx
@@ -1,25 +1,17 @@
-import {
-  informationCardTheme,
-  type InformationCardVariants,
-} from "./InformationCard.theme";
+import { informationCardTheme } from "./InformationCard.theme";
 import type { ReactNode } from "react";
-import { Button } from "@/common/components/Button";
 import { ClipboardIcon } from "@/common/components/CustomIcon";
-import { InformationModal } from "./InformationModal";
-import type { Courses } from "@prisma/client";
 import { InformationCardSkeleton } from "./InformationCardSkeleton";
-
-export type InformationCardProps = InformationCardVariants & {
-  course: Courses;
-  isLocked?: boolean;
-  children: ReactNode;
-};
+import { InformationCardLoginButton } from "./InformationCardLoginButton";
+import { InformationModal } from "./InformationModal";
 
 export const InformationCard = ({
-  course,
-  isLocked,
+  courseDesc,
   children,
-}: InformationCardProps) => {
+}: {
+  courseDesc: string;
+  children: ReactNode;
+}) => {
   const { wrapper, header, icon, content, description } =
     informationCardTheme();
   return (
@@ -29,17 +21,13 @@ export const InformationCard = ({
         <p>Information</p>
       </div>
       <div className={content()}>
-        <div className={description()}>{children}</div>
-        {isLocked ? (
-          <Button as="a" variant="link" href="/auth/login">
-            Login
-          </Button>
-        ) : (
-          <InformationModal course={course} />
-        )}
+        <div className={description()}>{courseDesc}</div>
+        {children}
       </div>
     </div>
   );
 };
 
 InformationCard.Skeleton = InformationCardSkeleton;
+InformationCard.LoginButton = InformationCardLoginButton;
+InformationCard.Modal = InformationModal;

--- a/src/modules/reviews/InformationSection/InformationCard/InformationCard.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCard.tsx
@@ -1,0 +1,36 @@
+import {
+  informationCardTheme,
+  type InformationCardVariants,
+} from "./InformationCard.theme";
+import type { ReactNode } from "react";
+import { Button } from "@/common/components/Button";
+import { ClipboardIcon } from "@/common/components/CustomIcon";
+
+export type InformationCardProps = InformationCardVariants & {
+  isLocked?: boolean;
+  children: ReactNode;
+};
+
+export const InformationCard = ({
+  isLocked,
+  children,
+}: InformationCardProps) => {
+  const { wrapper, header, icon, content, description } = informationCardTheme();
+  return (
+    <div className={wrapper()}>
+      <div className={header()}>
+        <ClipboardIcon className={icon()} />
+        <p>Information</p>
+      </div>
+      <div className={content()}>
+        <div className={description()}>{children}</div>
+        {isLocked ? (
+          <Button variant="link">Login</Button>
+        ) : (
+          // TODO: Open information modal
+          <Button variant="link">See more</Button>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/modules/reviews/InformationSection/InformationCard/InformationCard.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCard.tsx
@@ -5,17 +5,23 @@ import {
 import type { ReactNode } from "react";
 import { Button } from "@/common/components/Button";
 import { ClipboardIcon } from "@/common/components/CustomIcon";
+import { InformationModal } from "./InformationModal";
+import type { Courses } from "@prisma/client";
+import { InformationCardSkeleton } from "./InformationCardSkeleton";
 
 export type InformationCardProps = InformationCardVariants & {
+  course: Courses;
   isLocked?: boolean;
   children: ReactNode;
 };
 
 export const InformationCard = ({
+  course,
   isLocked,
   children,
 }: InformationCardProps) => {
-  const { wrapper, header, icon, content, description } = informationCardTheme();
+  const { wrapper, header, icon, content, description } =
+    informationCardTheme();
   return (
     <div className={wrapper()}>
       <div className={header()}>
@@ -25,12 +31,15 @@ export const InformationCard = ({
       <div className={content()}>
         <div className={description()}>{children}</div>
         {isLocked ? (
-          <Button variant="link">Login</Button>
+          <Button as="a" variant="link" href="/auth/login">
+            Login
+          </Button>
         ) : (
-          // TODO: Open information modal
-          <Button variant="link">See more</Button>
+          <InformationModal course={course} />
         )}
       </div>
     </div>
   );
 };
+
+InformationCard.Skeleton = InformationCardSkeleton;

--- a/src/modules/reviews/InformationSection/InformationCard/InformationCardLoginButton.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCardLoginButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Button } from "@/common/components/Button";
+import { usePathname } from "next/navigation";
+
+export const InformationCardLoginButton = () => {
+  const pathname = usePathname();
+  return (
+    <Button
+      as="a"
+      variant="link"
+      href={{
+        pathname: "/account/auth/login",
+        query: { callbackUrl: pathname },
+      }}
+    >
+      Login
+    </Button>
+  );
+};

--- a/src/modules/reviews/InformationSection/InformationCard/InformationCardSkeleton.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCardSkeleton.tsx
@@ -1,0 +1,21 @@
+import { informationCardTheme } from "./InformationCard.theme";
+import { ClipboardIcon } from "@/common/components/CustomIcon";
+import { Skeleton } from "@/common/components/Skeleton";
+
+export const InformationCardSkeleton = () => {
+  const { wrapper, header, icon, content, description } =
+    informationCardTheme();
+  return (
+    <div className={wrapper()}>
+      <div className={header()}>
+        <ClipboardIcon className={icon()} />
+        <p>Information</p>
+      </div>
+      <div className={content()}>
+        <div className={description()}>
+          <Skeleton className="h-[60px] w-full" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/reviews/InformationSection/InformationCard/InformationModal.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationModal.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Modal } from "@/common/components/Modal";
+import { type Courses } from "@prisma/client";
+import { informationCardTheme } from "./InformationCard.theme";
+import { Button } from "@/common/components/Button";
+
+export const InformationModal = ({
+  course,
+}: {
+  course: Courses;
+}) => {
+  const { content } = informationCardTheme();
+  return (
+    <Modal overflow="inside">
+      <Modal.Trigger asChild>
+        <div className={content()}>
+          <Button variant="link">See more</Button>
+        </div>
+      </Modal.Trigger>
+      <Modal.Content>
+        <Modal.Header>{course.name}</Modal.Header>
+        <Modal.Body>{course.description}</Modal.Body>
+      </Modal.Content>
+    </Modal>
+  );
+};

--- a/src/modules/reviews/InformationSection/InformationCard/InformationModal.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationModal.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { Modal } from "@/common/components/Modal";
-import { type Courses } from "@prisma/client";
 import { informationCardTheme } from "./InformationCard.theme";
 import { Button } from "@/common/components/Button";
 
 export const InformationModal = ({
-  course,
+  courseName,
+  courseDesc,
 }: {
-  course: Courses;
+  courseName: string;
+  courseDesc: string;
 }) => {
   const { content } = informationCardTheme();
   return (
@@ -19,8 +20,8 @@ export const InformationModal = ({
         </div>
       </Modal.Trigger>
       <Modal.Content>
-        <Modal.Header>{course.name}</Modal.Header>
-        <Modal.Body>{course.description}</Modal.Body>
+        <Modal.Header>{courseName}</Modal.Header>
+        <Modal.Body>{courseDesc}</Modal.Body>
       </Modal.Content>
     </Modal>
   );

--- a/src/modules/reviews/InformationSection/InformationCard/index.ts
+++ b/src/modules/reviews/InformationSection/InformationCard/index.ts
@@ -1,0 +1,2 @@
+export * from "./InformationCard"
+export * from "./InformationCard.theme"


### PR DESCRIPTION
## Context
This PR addresses issue #88 and focuses on the implementation of the information component for the course page. The key features are as follows:
- Unauthenticated Users: They will see a truncated version of the information (up to 3 lines) along with a `login` link that redirects them to the login page.
- Authenticated Users: They will also see the truncated information, but with a `see more` link. Clicking this link will open a modal displaying the full course information.

## Implementation Decisions
For the Information Card, I have chosen a composition design by allowing the card component to accept `Log In Button` and `Modal` as children. This approach was adopted for several reasons:
- Minimise Prop Drilling: By passing these components as children, we avoid passing unnecessary props through multiple levels, reducing prop drilling.
- Server Vs Client Components: Both the Log In Button and Modal are client-based components. By extracting these parts out of the parent `InformationCard` component, the card itself and the page that uses it can remain as server-based components.

Initially, I considered consolidating the rendering of the button and modal into a single component (e.g., placing the button within the modal component since both are client-based). However, this approach might violate separation of concerns and it does not address the issue of prop drilling. Additionally, it is inconsistent with our current component design, which favours a composition-based approach over a component-based one.

## Changes
- new parallel route `@Information`
- information card components (including theme, skeleton, login button & modal)
- new clipboard icon

## Note
Course detail component will be implemented in a separate PR

## Testing
all reviews for selected course: https://afterclass-io-v2-git-feat-course-page-info-section-afterclass.vercel.app/course/COR-IS1702

## Preview

### Unauthenticated
<img width="1045" alt="Screenshot 2024-05-29 at 12 13 52 AM" src="https://github.com/AfterClass-io/afterclass.io-v2/assets/68802506/0bca3e5d-ce59-4c3f-8f1d-f0ac2d3e8418">

### Authenticated
<img width="1006" alt="Screenshot 2024-05-29 at 12 13 08 AM" src="https://github.com/AfterClass-io/afterclass.io-v2/assets/68802506/c7e9f730-9cc5-4edf-a41e-67d8602c2c88">

### Modal
<img width="948" alt="Screenshot 2024-05-29 at 12 13 20 AM" src="https://github.com/AfterClass-io/afterclass.io-v2/assets/68802506/3970f89a-affb-4190-82dc-24befdfb1c6f">
