### PR TITLE
feat(UI): Course Page Detail Card

### DIFF
--- a/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/loading.tsx
@@ -1,12 +1,15 @@
 import { InformationCard } from "@/modules/reviews/InformationSection/InformationCard";
+import { DetailCard } from "@/modules/reviews/InformationSection/DetailCard";
 
 export default function Loading() {
   return (
-    <div className="flex w-full gap-6">
-      <div className="w-2/3">
+    <div className="flex w-full flex-wrap gap-6 md:flex-nowrap">
+      <div className="w-full md:w-2/3">
         <InformationCard.Skeleton />
       </div>
-      <div className="w-1/3">TODO: course detail</div>
+      <div className="w-full md:w-1/3">
+        <DetailCard.Skeleton />
+      </div>
     </div>
   );
 }

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -17,8 +17,8 @@ export default async function CourseInfo({
     return notFound();
   }
   return (
-    <div className="flex w-full gap-6">
-      <div className="w-2/3">
+    <div className="flex w-full flex-wrap gap-6 md:flex-nowrap">
+      <div className="w-full md:w-2/3">
         <InformationCard courseDesc={course.description}>
           {!session ? (
             <InformationCard.LoginButton />

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -31,7 +31,7 @@ export default async function CourseInfo({
         </InformationCard>
       </div>
       <div className="w-full md:w-1/3">
-        <DetailCard course={course} />
+        <DetailCard courseCode={course.code} courseCU={course.creditUnits} />
       </div>
     </div>
   );

--- a/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@information/course/[code]/page.tsx
@@ -1,6 +1,7 @@
 import { api } from "@/common/tools/trpc/server";
 import { notFound } from "next/navigation";
 import { InformationCard } from "@/modules/reviews/InformationSection/InformationCard";
+import { DetailCard } from "@/modules/reviews/InformationSection/DetailCard";
 import { getServerAuthSession } from "@/server/auth";
 
 export default async function CourseInfo({
@@ -29,7 +30,9 @@ export default async function CourseInfo({
           )}
         </InformationCard>
       </div>
-      <div className="w-1/3">TODO: course detail</div>
+      <div className="w-full md:w-1/3">
+        <DetailCard course={course} />
+      </div>
     </div>
   );
 }

--- a/src/modules/reviews/InformationSection/DetailCard/DetailCard.theme.ts
+++ b/src/modules/reviews/InformationSection/DetailCard/DetailCard.theme.ts
@@ -1,0 +1,27 @@
+import { type VariantProps, tv } from "tailwind-variants";
+
+export type DetailCardVariations = VariantProps<typeof DetailCardTheme>;
+
+export const DetailCardTheme = tv(
+  {
+    slots: {
+      wrapper: [
+        "w-full",
+        "h-full",
+        "flex",
+        "flex-col",
+        "bg-surface-base",
+        "rounded-2xl",
+        "gap-5",
+        "p-6",
+        "text-base",
+      ],
+      header: ["text-2xl", "font-semibold", "text-text-em-high"],
+      body: ["flex", "flex-col", "gap-3"],
+      content: ["flex", "gap-3", "text-lg", "font-medium"],
+      field: ["text-text-em-mid"],
+      value: ["text-text-em-high"],
+    },
+  },
+  { responsiveVariants: true },
+);

--- a/src/modules/reviews/InformationSection/DetailCard/DetailCard.tsx
+++ b/src/modules/reviews/InformationSection/DetailCard/DetailCard.tsx
@@ -1,8 +1,13 @@
-import { type Courses } from "@prisma/client";
 import { DetailCardTheme } from "./DetailCard.theme";
 import { DetailCardSkeleton } from "./DetailCardSkeleton";
 
-export const DetailCard = ({ course }: { course: Courses }) => {
+export const DetailCard = ({
+  courseCode,
+  courseCU,
+}: {
+  courseCode: string;
+  courseCU: number;
+}) => {
   const { wrapper, header, body, content, field, value } = DetailCardTheme();
   return (
     <div className={wrapper()}>
@@ -12,11 +17,11 @@ export const DetailCard = ({ course }: { course: Courses }) => {
       <div className={body()}>
         <div className={content()}>
           <p className={field()}>Course code</p>
-          <p className={value()}>{course.code}</p>
+          <p className={value()}>{courseCode}</p>
         </div>
         <div className={content()}>
           <p className={field()}>Credit unit</p>
-          <p className={value()}>{course.creditUnits}</p>
+          <p className={value()}>{courseCU}</p>
         </div>
       </div>
     </div>

--- a/src/modules/reviews/InformationSection/DetailCard/DetailCard.tsx
+++ b/src/modules/reviews/InformationSection/DetailCard/DetailCard.tsx
@@ -1,0 +1,26 @@
+import { type Courses } from "@prisma/client";
+import { DetailCardTheme } from "./DetailCard.theme";
+import { DetailCardSkeleton } from "./DetailCardSkeleton";
+
+export const DetailCard = ({ course }: { course: Courses }) => {
+  const { wrapper, header, body, content, field, value } = DetailCardTheme();
+  return (
+    <div className={wrapper()}>
+      <div className={header()}>
+        <p>Details</p>
+      </div>
+      <div className={body()}>
+        <div className={content()}>
+          <p className={field()}>Course Code</p>
+          <p className={value()}>{course.code}</p>
+        </div>
+        <div className={content()}>
+          <p className={field()}>Credit Unit</p>
+          <p className={value()}>{course.creditUnits}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+DetailCard.Skeleton = DetailCardSkeleton;

--- a/src/modules/reviews/InformationSection/DetailCard/DetailCard.tsx
+++ b/src/modules/reviews/InformationSection/DetailCard/DetailCard.tsx
@@ -11,11 +11,11 @@ export const DetailCard = ({ course }: { course: Courses }) => {
       </div>
       <div className={body()}>
         <div className={content()}>
-          <p className={field()}>Course Code</p>
+          <p className={field()}>Course code</p>
           <p className={value()}>{course.code}</p>
         </div>
         <div className={content()}>
-          <p className={field()}>Credit Unit</p>
+          <p className={field()}>Credit unit</p>
           <p className={value()}>{course.creditUnits}</p>
         </div>
       </div>

--- a/src/modules/reviews/InformationSection/DetailCard/DetailCardSkeleton.tsx
+++ b/src/modules/reviews/InformationSection/DetailCard/DetailCardSkeleton.tsx
@@ -1,0 +1,17 @@
+import { DetailCardTheme } from "./DetailCard.theme";
+import { Skeleton } from "@/common/components/Skeleton";
+
+export const DetailCardSkeleton = () => {
+  const { wrapper, header, body } = DetailCardTheme();
+  return (
+    <div className={wrapper()}>
+      <div className={header()}>
+        <p>Details</p>
+      </div>
+      <div className={body()}>
+        <Skeleton className="h-[20px] w-full" />
+        <Skeleton className="h-[20px] w-full" />
+      </div>
+    </div>
+  );
+};

--- a/src/modules/reviews/InformationSection/DetailCard/index.ts
+++ b/src/modules/reviews/InformationSection/DetailCard/index.ts
@@ -1,0 +1,2 @@
+export * from "./DetailCard";
+export * from "./DetailCard.theme";


### PR DESCRIPTION
## Context
This PR addresses issue #88 and focuses on the implementation of the details component for the course page. This section will be displayed as it is to both authenticated and unauthenticated user.

Merging this PR closes #88 

## Changes
- detail card components (including theme & skeleton)
- detail card implementation for course page (including loading state)

## Testing
all reviews for selected course:https://afterclass-io-v2-git-feat-course-page-detail-section-afterclass.vercel.app/course/COR-IS1702

## Preview

### Loading
![photo_2024-05-29 00 58 17](https://github.com/AfterClass-io/afterclass.io-v2/assets/68802506/239761ad-6e55-4eae-a908-b342cf0155a6)

### Loaded
<img width="1016" alt="Screenshot 2024-05-29 at 1 01 27 AM" src="https://github.com/AfterClass-io/afterclass.io-v2/assets/68802506/3b6de6e1-8c36-49ec-9e30-377a2916af84">
