### PR TITLE
fix: close button autofocus instead of input on open modal

### DIFF
--- a/src/common/components/Modal/ModalContent/ModalContent.tsx
+++ b/src/common/components/Modal/ModalContent/ModalContent.tsx
@@ -43,6 +43,7 @@ export const ModalContent = ({
           {...preventClickOutsideToCloseProps}
           {...props}
         >
+          {children}
           {hasCloseButton && (
             <Close asChild>
               <Button
@@ -60,7 +61,6 @@ export const ModalContent = ({
               />
             </Close>
           )}
-          {children}
         </Content>
       </Overlay>
     </Portal>


### PR DESCRIPTION
## context

When a radix-ui modal is opened, it auto focuses the first thing in content. See `https://github.com/radix-ui/primitives/blob/main/packages/react/focus-scope/src/FocusScope.tsx`

Currently, the first element in content is the close button so it'll focus on that instead of the input element

This change is meant to fix that behavior and have the input component be focused on instead

## change

- swap order of content children so that input component comes first