### PR TITLE
feat: expose user fields to session object

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -176,7 +176,8 @@ export const authOptions: NextAuthOptions = {
       return baseUrl;
     },
     jwt({ token, user }) {
-      if (user) {
+      if (token.sub && user) {
+        // strip user object of unwanted sensitive fields before populating to token
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { deprecatedPasswordDigest, ...rest } = user as Users;
         // to expose user object in session

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -13,6 +13,9 @@ import { signInWithEmail } from "./supabase";
 import { emailValidationSchema } from "@/common/tools/zod/schemas";
 import { db } from "@/server/db";
 import randomId from "@/common/functions/randomId";
+import { type Users } from "@prisma/client";
+
+type SessionUser = Omit<Users, "deprecatedPasswordDigest">;
 
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
@@ -22,17 +25,8 @@ import randomId from "@/common/functions/randomId";
  */
 declare module "next-auth" {
   interface Session extends DefaultSession {
-    user: {
-      id: string;
-      // ...other properties not defined in `DefaultSession["user"]`
-      // role: UserRole;
-    } & DefaultSession["user"];
+    user: SessionUser;
   }
-
-  // interface User {
-  //   // ...other properties
-  //   // role: UserRole;
-  // }
 }
 
 /**
@@ -180,6 +174,20 @@ export const authOptions: NextAuthOptions = {
       // Allows callback URLs on the same origin
       else if (new URL(url).origin === baseUrl) return url;
       return baseUrl;
+    },
+    jwt({ token, user }) {
+      if (!token.sub) return token;
+      if (user) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { deprecatedPasswordDigest, ...rest } = user as Users;
+        // to expose user object in session
+        token.user = rest;
+      }
+      return token;
+    },
+    session({ session, token }) {
+      if (token?.user) session.user = token.user as SessionUser;
+      return session;
     },
   },
 };

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -176,9 +176,6 @@ export const authOptions: NextAuthOptions = {
       return baseUrl;
     },
     jwt({ token, user }) {
-      if (!token.sub) {
-        return token;
-      }
       if (user) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { deprecatedPasswordDigest, ...rest } = user as Users;

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -176,7 +176,9 @@ export const authOptions: NextAuthOptions = {
       return baseUrl;
     },
     jwt({ token, user }) {
-      if (!token.sub) return token;
+      if (!token.sub) {
+        return token;
+      }
       if (user) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { deprecatedPasswordDigest, ...rest } = user as Users;
@@ -186,7 +188,9 @@ export const authOptions: NextAuthOptions = {
       return token;
     },
     session({ session, token }) {
-      if (token?.user) session.user = token.user as SessionUser;
+      if (token?.user) {
+        session.user = token.user as SessionUser;
+      }
       return session;
     },
   },


### PR DESCRIPTION
partially addresses #78 

## Context

<!--- Describe the reason for this change -->

This is done as a next step to #175 as user fields from prisma schema isn't exposed to the session object and hence, is not available for use like `session.user.username`

## Changes

<!--- Describe your changes -->

add user object to jwt token and get session object to update it's user field based on the token value

this jwt stores data representing the logged in user and some parts of the session data

## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->

- https://next-auth.js.org/configuration/callbacks#jwt-callback
- https://next-auth.js.org/configuration/callbacks#session-callback

## How to Test

<!--- Describe how to test your changes -->

login and should see username instead of blank name at the top right corner of profile header

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/58da032d-14be-449a-83e8-fb5159ced3f2)


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
