### PR TITLE
feat: search result includes review statistics

### DIFF
--- a/src/common/components/SearchResult/SearchResult.stories.tsx
+++ b/src/common/components/SearchResult/SearchResult.stories.tsx
@@ -29,21 +29,29 @@ const searchedCourse = [
     uniAbbrv: "SMU",
     courseCode: "IS215",
     courseName: "Course 1",
+    profCount: 21,
+    reviewCount: 22,
   },
   {
     uniAbbrv: "SMU",
     courseCode: "IS216",
     courseName: "Course 1a",
+    profCount: 23,
+    reviewCount: 24,
   },
   {
     uniAbbrv: "NUS",
     courseCode: "CS1010",
     courseName: "Course 2",
+    profCount: 25,
+    reviewCount: 26,
   },
   {
     uniAbbrv: "NTU",
     courseCode: "CS101",
     courseName: "Course 3",
+    profCount: 27,
+    reviewCount: 288,
   },
 ] satisfies SearchCourseResult[];
 
@@ -52,21 +60,29 @@ const searchedProf = [
     uniAbbrv: "SMU",
     profName: "Prof 1",
     profSlug: "prof-1",
+    courseCount: 11,
+    reviewCount: 12,
   },
   {
     uniAbbrv: "SMU",
     profName: "Prof 1a",
     profSlug: "prof-1a",
+    courseCount: 13,
+    reviewCount: 14,
   },
   {
     uniAbbrv: "NUS",
     profName: "Prof 2",
     profSlug: "prof-2",
+    courseCount: 15,
+    reviewCount: 16,
   },
   {
     uniAbbrv: "NTU",
     profName: "Prof 3",
     profSlug: "prof-3",
+    courseCount: 17,
+    reviewCount: 188,
   },
 ] satisfies SearchProfResult[];
 

--- a/src/common/components/SearchResult/SearchResultContent/SearchResultContent.tsx
+++ b/src/common/components/SearchResult/SearchResultContent/SearchResultContent.tsx
@@ -75,8 +75,8 @@ export const SearchResultContent = ({
               title={c.courseName}
               subtitle={c.courseCode}
               filterStats={[
-                { icon: <PencilIcon />, stat: 12 },
-                { icon: <GraduationCapIcon />, stat: 32 },
+                { icon: <PencilIcon />, stat: c.reviewCount },
+                { icon: <GraduationCapIcon />, stat: c.profCount },
               ]}
             />
           ))}
@@ -88,8 +88,8 @@ export const SearchResultContent = ({
               href={`/professor/${p.profSlug}`}
               title={p.profName}
               filterStats={[
-                { icon: <PencilIcon />, stat: 11 },
-                { icon: <BooksIcon />, stat: 31 },
+                { icon: <PencilIcon />, stat: p.reviewCount },
+                { icon: <BooksIcon />, stat: p.courseCount },
               ]}
             />
           ))}

--- a/src/common/functions/searchCourse.ts
+++ b/src/common/functions/searchCourse.ts
@@ -1,15 +1,20 @@
 import type { Universities, Courses } from "@prisma/client";
 import { db } from "@/server/db";
+import { api } from "@/common/tools/trpc/server";
 
-export type SearchCourseResult = {
+type QueryCourseResult = {
   uniAbbrv: Universities["abbrv"];
   courseCode: Courses["code"];
   courseName: Courses["name"];
 };
 
+export type SearchCourseResult = QueryCourseResult & {
+  profCount: number;
+  reviewCount: number;
+};
 // this is a band-aid solution
 // TODO: replace with better search algorithm
-export function searchCourse(
+export async function searchCourse(
   query: string,
   limit: number = 5,
 ): Promise<SearchCourseResult[]> {
@@ -19,7 +24,7 @@ export function searchCourse(
     ? query.split(" ").join(" & ")
     : query;
 
-  return db.$queryRaw`
+  const queryResult: QueryCourseResult[] = await db.$queryRaw`
     SELECT
       u.abbrv as "uniAbbrv",
       c.code as "courseCode",
@@ -35,4 +40,18 @@ export function searchCourse(
       @@ to_tsquery(${processedQuery + ":*"})
     LIMIT ${limit};
   `;
+
+  return Promise.all(
+    queryResult.map(async (r) => {
+      const [profCount, reviewCount] = await Promise.all([
+        await api.professors.countByCourseCode({ courseCode: r.courseCode }),
+        await api.reviews.countByCourseCode({ courseCode: r.courseCode }),
+      ]);
+      return {
+        ...r,
+        profCount,
+        reviewCount,
+      };
+    }),
+  );
 }

--- a/src/common/functions/searchProf.ts
+++ b/src/common/functions/searchProf.ts
@@ -1,15 +1,21 @@
 import type { Universities, Professors } from "@prisma/client";
 import { db } from "@/server/db";
+import { api } from "@/common/tools/trpc/server";
 
-export type SearchProfResult = {
+type QueryProfResult = {
   uniAbbrv: Universities["abbrv"];
   profName: Professors["name"];
   profSlug: Professors["slug"];
 };
 
+export type SearchProfResult = QueryProfResult & {
+  courseCount: number;
+  reviewCount: number;
+};
+
 // this is a band-aid solution
 // TODO: replace with better search algorithm
-export function searchProf(
+export async function searchProf(
   query: string,
   limit: number = 5,
 ): Promise<SearchProfResult[]> {
@@ -19,7 +25,7 @@ export function searchProf(
     ? query.split(" ").join(" & ")
     : query;
 
-  return db.$queryRaw`
+  const queryResult: QueryProfResult[] = await db.$queryRaw`
     SELECT
       u.abbrv as "uniAbbrv",
       p.name as "profName",
@@ -35,4 +41,18 @@ export function searchProf(
       @@ to_tsquery(${processedQuery + ":*"})
     LIMIT ${limit};
   `;
+
+  return Promise.all(
+    queryResult.map(async (r) => {
+      const [courseCount, reviewCount] = await Promise.all([
+        await api.courses.countByProfSlug({ slug: r.profSlug }),
+        await api.reviews.countByProfessorSlug({ slug: r.profSlug }),
+      ]);
+      return {
+        ...r,
+        courseCount,
+        reviewCount,
+      };
+    }),
+  );
 }


### PR DESCRIPTION
closes #162 

## Context

<!--- Describe the reason for this change -->

Previously, in #152 #161 , the search did not include querying for review statistics. This change adds that functionality to include the respective review statistics along with each search result.

## Changes

<!--- Describe your changes -->

Add an additional db query to fetch review statistics (prof count, course count, review count)

## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->

- use `Promise.all` to guarantee return structure and reduce wait time

## How to Test

<!--- Describe how to test your changes -->

1. head to home
2. press `/` to bring up search bar
3. search something simple, like `o` 
4. see results -> should have the relevant review statistics

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->

![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/3357280c-a96c-4445-b973-ac700da39f99)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [x] _(where applicable)_ I have added tests to cover my changes
