### PR TITLE
feat(ui): see more button links to respective page on review modal

### DIFF
--- a/src/common/components/ReviewModal/ReviewModal.tsx
+++ b/src/common/components/ReviewModal/ReviewModal.tsx
@@ -8,6 +8,7 @@ import { reviewModalTheme } from "./ReviewModal.theme";
 import { getHumanReadableTimestampDelta } from "@/common/functions";
 import { ShareIcon, ThumbUpFilledIcon } from "@/common/components/CustomIcon";
 import { type Review } from "@/common/types";
+import Link from "next/link";
 
 export const ReviewModal = ({
   review,
@@ -33,6 +34,10 @@ export const ReviewModal = ({
     seeMoreLink,
   } = reviewModalTheme();
 
+  const reviewPath =
+    review.reviewFor === "professor"
+      ? `/professor/${review.professorName}`
+      : `/course/${review.courseCode}`;
   return (
     <Modal overflow="inside">
       <Modal.Trigger asChild className={modalTrigger()}>
@@ -71,11 +76,12 @@ export const ReviewModal = ({
           {/* seeMore link only shown when user is from default reviews page, hidden when in professor/course pages */}
           {seeMore && (
             <div className={seeMoreWrapper()}>
-              <div className={seeMoreLink()}>
-                {/* TODO: link to respective prof/course page */}
-                {/* can use review.professorName for professors and review.courseCode for courses */}
+              <Link
+                href={`${reviewPath.replace(/\s+/g, "-")}`}
+                className={seeMoreLink()}
+              >
                 See more reviews
-              </div>
+              </Link>
             </div>
           )}
         </Modal.Body>

--- a/src/common/components/ReviewModal/ReviewModal.tsx
+++ b/src/common/components/ReviewModal/ReviewModal.tsx
@@ -8,7 +8,7 @@ import { reviewModalTheme } from "./ReviewModal.theme";
 import { getHumanReadableTimestampDelta } from "@/common/functions";
 import { ShareIcon, ThumbUpFilledIcon } from "@/common/components/CustomIcon";
 import { type Review } from "@/common/types";
-import Link from "next/link";
+import { Button } from "@/common/components/Button";
 
 export const ReviewModal = ({
   review,
@@ -36,8 +36,9 @@ export const ReviewModal = ({
 
   const reviewPath =
     review.reviewFor === "professor"
-      ? `/professor/${review.professorName}`
+      ? `/professor/${review.professorSlug}`
       : `/course/${review.courseCode}`;
+
   return (
     <Modal overflow="inside">
       <Modal.Trigger asChild className={modalTrigger()}>
@@ -76,12 +77,14 @@ export const ReviewModal = ({
           {/* seeMore link only shown when user is from default reviews page, hidden when in professor/course pages */}
           {seeMore && (
             <div className={seeMoreWrapper()}>
-              <Link
-                href={`${reviewPath.replace(/\s+/g, "-")}`}
+              <Button
+                as="a"
+                variant="link"
+                href={reviewPath}
                 className={seeMoreLink()}
               >
                 See more reviews
-              </Link>
+              </Button>
             </div>
           )}
         </Modal.Body>

--- a/src/common/types/review.ts
+++ b/src/common/types/review.ts
@@ -13,4 +13,5 @@ export type Review = {
   university: UniversityAbbreviation;
   reviewFor: "professor" | "course";
   professorName?: string;
+  professorSlug?: string;
 };

--- a/src/server/api/routers/reviews.ts
+++ b/src/server/api/routers/reviews.ts
@@ -166,6 +166,7 @@ export const reviewsRouter = createTRPCRouter({
                 ? ("professor" as "professor" | "course")
                 : ("course" as "professor" | "course"),
             professorName: review.reviewedProfessor?.name,
+            professorSlug: review.reviewedProfessor?.slug,
             university: review.reviewedUniversity.abbrv,
           }) satisfies Review,
       );
@@ -211,6 +212,7 @@ export const reviewsRouter = createTRPCRouter({
                 ? ("professor" as "professor" | "course")
                 : ("course" as "professor" | "course"),
             professorName: review.reviewedProfessor?.name,
+            professorSlug: review.reviewedProfessor?.slug,
             university: review.reviewedUniversity.abbrv,
           }) satisfies Review,
       );
@@ -254,6 +256,7 @@ export const reviewsRouter = createTRPCRouter({
                 ? ("professor" as "professor" | "course")
                 : ("course" as "professor" | "course"),
             professorName: review.reviewedProfessor?.name,
+            professorSlug: review.reviewedProfessor?.slug,
             university: review.reviewedUniversity.abbrv,
           }) satisfies Review,
       );
@@ -299,6 +302,7 @@ export const reviewsRouter = createTRPCRouter({
                 ? ("professor" as "professor" | "course")
                 : ("course" as "professor" | "course"),
             professorName: review.reviewedProfessor?.name,
+            professorSlug: review.reviewedProfessor?.slug,
             university: review.reviewedUniversity.abbrv,
           }) satisfies Review,
       );
@@ -345,6 +349,7 @@ export const reviewsRouter = createTRPCRouter({
                 ? ("professor" as "professor" | "course")
                 : ("course" as "professor" | "course"),
             professorName: review.reviewedProfessor?.name,
+            professorSlug: review.reviewedProfessor?.slug,
             university: review.reviewedUniversity.abbrv,
           }) satisfies Review,
       );
@@ -393,6 +398,7 @@ export const reviewsRouter = createTRPCRouter({
                 ? ("professor" as "professor" | "course")
                 : ("course" as "professor" | "course"),
             professorName: review.reviewedProfessor?.name,
+            professorSlug: review.reviewedProfessor?.slug,
             university: review.reviewedUniversity.abbrv,
           }) satisfies Review,
       );


### PR DESCRIPTION
closes #164 

## Context

implement see more review and link to the respective professor/course page

## Changes

added link


## How to Test

go to default reviews page and click see more reviews in the modal


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
