### PR TITLE
fix: inaccurate review statistics on filter

### DIFF
--- a/src/app/(school)/(reviews)/@filter/course/[code]/page.tsx
+++ b/src/app/(school)/(reviews)/@filter/course/[code]/page.tsx
@@ -19,7 +19,10 @@ export default async function CourseFilter({
     professorForThisCourse.map(async (professor) => {
       const [courseCount, reviewCount] = await Promise.all([
         await api.courses.countByProfSlug({ slug: professor.slug }),
-        await api.reviews.countByProfessorSlug({ slug: professor.slug }),
+        await api.reviews.count({
+          profSlug: professor.slug,
+          courseCode: params.code,
+        }),
       ]);
       return {
         ...professor,

--- a/src/app/(school)/(reviews)/@filter/professor/[slug]/page.tsx
+++ b/src/app/(school)/(reviews)/@filter/professor/[slug]/page.tsx
@@ -23,8 +23,9 @@ export default async function ProfessorFilter({
         api.professors.countByCourseCode({
           courseCode: course.code,
         }),
-        api.reviews.countByCourseCode({
+        api.reviews.count({
           courseCode: course.code,
+          profSlug: params.slug,
         }),
       ]);
       return {

--- a/src/common/functions/searchCourse.ts
+++ b/src/common/functions/searchCourse.ts
@@ -45,7 +45,7 @@ export async function searchCourse(
     queryResult.map(async (r) => {
       const [profCount, reviewCount] = await Promise.all([
         await api.professors.countByCourseCode({ courseCode: r.courseCode }),
-        await api.reviews.countByCourseCode({ courseCode: r.courseCode }),
+        await api.reviews.count({ courseCode: r.courseCode }),
       ]);
       return {
         ...r,

--- a/src/common/functions/searchProf.ts
+++ b/src/common/functions/searchProf.ts
@@ -46,7 +46,7 @@ export async function searchProf(
     queryResult.map(async (r) => {
       const [courseCount, reviewCount] = await Promise.all([
         await api.courses.countByProfSlug({ slug: r.profSlug }),
-        await api.reviews.countByProfessorSlug({ slug: r.profSlug }),
+        await api.reviews.count({ profSlug: r.profSlug }),
       ]);
       return {
         ...r,

--- a/src/server/api/routers/reviews.ts
+++ b/src/server/api/routers/reviews.ts
@@ -398,8 +398,13 @@ export const reviewsRouter = createTRPCRouter({
       );
     }),
 
-  countByCourseCode: publicProcedure
-    .input(z.object({ courseCode: z.string() }))
+  count: publicProcedure
+    .input(
+      z.object({
+        profSlug: z.string().optional(),
+        courseCode: z.string().optional(),
+      }),
+    )
     .query(
       async ({ ctx, input }) =>
         await ctx.db.reviews.count({
@@ -407,22 +412,8 @@ export const reviewsRouter = createTRPCRouter({
             reviewedCourse: {
               code: input.courseCode,
             },
-          },
-        }),
-    ),
-
-  countByProfessorSlug: publicProcedure
-    .input(
-      z.object({
-        slug: z.string(),
-      }),
-    )
-    .query(
-      async ({ ctx, input }) =>
-        await ctx.db.reviews.count({
-          where: {
             reviewedProfessor: {
-              slug: input.slug,
+              slug: input.profSlug,
             },
           },
         }),


### PR DESCRIPTION
closes #181 

## Context

<!--- Describe the reason for this change -->
When user want to filter a professor's review by course, the filter checkbox MUST reflect the correct statistics of how many review the user should expect when they filter by that course

## Changes

<!--- Describe your changes -->
allow review count api to accept both course code and prof slug to count more accurately by:
- \+ renamed count api
- \+ count api accepts optional prof slug and course code (if neither are given, then all review count is returned)
- \- removed previous countByX apis

## How to Test

<!--- Describe how to test your changes -->

1. search prof `vivien soon`
2. see that stats now accurately reflects 0 reviews for this prof for the mod `COR-IS1702`

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->
![image](https://github.com/AfterClass-io/afterclass.io-v2/assets/13061926/cd4762d9-13e1-4111-80c2-4143b7162da9)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
