### PR TITLE
fix: prof filter on course page not correctly filtering reviews

### DIFF
--- a/src/server/api/routers/reviews.ts
+++ b/src/server/api/routers/reviews.ts
@@ -323,7 +323,7 @@ export const reviewsRouter = createTRPCRouter({
         take: DEFAULT_PAGE_SIZE,
         where: {
           reviewedCourse: { code: input.code },
-          reviewedProfessor: input.slugs && { slug: { in: input.slugs } },
+          reviewedProfessor: { slug: { in: input.slugs } },
         },
         orderBy: input.latest ? { createdAt: "desc" } : undefined,
         select: PRIVATE_REVIEW_FIELDS,
@@ -366,7 +366,7 @@ export const reviewsRouter = createTRPCRouter({
         take: DEFAULT_PAGE_SIZE,
         where: {
           reviewedCourse: { code: input.code },
-          reviewedProfessor: input.slugs && { slug: { in: input.slugs } },
+          reviewedProfessor: { slug: { in: input.slugs } },
         },
         orderBy: input.latest ? { createdAt: "desc" } : undefined,
         select: PRIVATE_REVIEW_FIELDS,

--- a/src/server/api/routers/reviews.ts
+++ b/src/server/api/routers/reviews.ts
@@ -323,11 +323,7 @@ export const reviewsRouter = createTRPCRouter({
         take: DEFAULT_PAGE_SIZE,
         where: {
           reviewedCourse: { code: input.code },
-          // reviewedProfessor is in slugs or reviewedProfessorId is null
-          OR: [
-            { reviewedProfessor: { slug: { in: input.slugs } } },
-            { reviewedProfessorId: null },
-          ],
+          reviewedProfessor: input.slugs && { slug: { in: input.slugs } },
         },
         orderBy: input.latest ? { createdAt: "desc" } : undefined,
         select: PRIVATE_REVIEW_FIELDS,
@@ -370,11 +366,7 @@ export const reviewsRouter = createTRPCRouter({
         take: DEFAULT_PAGE_SIZE,
         where: {
           reviewedCourse: { code: input.code },
-          // reviewedProfessor is in slugs or reviewedProfessorId is null
-          OR: [
-            { reviewedProfessor: { slug: { in: input.slugs } } },
-            { reviewedProfessorId: null },
-          ],
+          reviewedProfessor: input.slugs && { slug: { in: input.slugs } },
         },
         orderBy: input.latest ? { createdAt: "desc" } : undefined,
         select: PRIVATE_REVIEW_FIELDS,


### PR DESCRIPTION
closes #180

## Context

<!--- Describe the reason for this change -->
When we filter a course page for a particular prof, we expect to only see information / reviews of this prof for this course and nothing else.

The current behavior is to show all course reviews that are not tagged to a prof, along with that particular prof's reviews. Hence filtering for profs that dont have reviews still unexpectedly show reviews in the review section as those reviews are only written for courses and do not have a corresponsing `reviewedProfessor`

## Changes

<!--- Describe your changes -->
update reviews trpc procedure's primsa query when fetching for reviews belonging to this course when filtered by a particular prof

## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->
query for reviews with prof slug only when slug exists in the input param of the trpc procedure, otherwise, get all course reviews


## How to Test

<!--- Describe how to test your changes -->
1. head to `/course/COR-IS1702`
2. filter on profs with 0 reviews
3. no longer see reviews on review section

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->

### No Filter
![image](https://github.com/user-attachments/assets/2e4f6a70-a91c-4bc9-ac1a-43b0e221033e)

### Filtering for Prof with Reviews

Stats are different from no filter version as there are course reviews that arent reviewed with a prof

![image](https://github.com/user-attachments/assets/b0246456-769e-47e6-a13a-5a90746acab3)

### Filtering for Prof with Reviews
![image](https://github.com/user-attachments/assets/55ee3632-41c7-48b9-a567-efac1bdcd897)


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
