### PR TITLE
fix: prevent review modal close button autofocus

### DIFF
--- a/src/common/components/ReviewModal/ReviewModal.tsx
+++ b/src/common/components/ReviewModal/ReviewModal.tsx
@@ -47,7 +47,10 @@ export const ReviewModal = ({
           <ReviewBody isDetailed={variant !== "home"} review={review} />
         </div>
       </Modal.Trigger>
-      <Modal.Content className={modalContent()}>
+      <Modal.Content
+        className={modalContent()}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <Modal.Header>
           <ProfileSchool
             courseCode={review.courseCode}


### PR DESCRIPTION
closes #169

## Changes

<!--- Describe your changes -->
- Add preventDefault to [`onOpenAutoFocus`](https://www.radix-ui.com/primitives/docs/components/dialog#content) to `<Modal.Content/>` component

![image](https://github.com/user-attachments/assets/bf9ad565-be9c-4aaf-90bd-136aa844c179)

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->



## How to Test

1. head to `/`
2. open a review item modal
3. no longer see close button autofocusing

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
