### PR TITLE
fix: add whitespace pre wrap for modal body

### DIFF
--- a/src/modules/reviews/InformationSection/InformationCard/InformationCard.theme.ts
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationCard.theme.ts
@@ -26,6 +26,7 @@ export const informationCardTheme = tv(
       icon: ["h-6", "w-6"],
       content: ["flex", "flex-col", "gap-2"],
       description: ["line-clamp-3", "text-text-em-high"],
+      body: ["whitespace-pre-wrap"]
     },
   },
   { responsiveVariants: true },

--- a/src/modules/reviews/InformationSection/InformationCard/InformationModal.tsx
+++ b/src/modules/reviews/InformationSection/InformationCard/InformationModal.tsx
@@ -11,7 +11,7 @@ export const InformationModal = ({
   courseName: string;
   courseDesc: string;
 }) => {
-  const { content } = informationCardTheme();
+  const { content, body } = informationCardTheme();
   return (
     <Modal overflow="inside">
       <Modal.Trigger asChild>
@@ -21,7 +21,7 @@ export const InformationModal = ({
       </Modal.Trigger>
       <Modal.Content>
         <Modal.Header>{courseName}</Modal.Header>
-        <Modal.Body>{courseDesc}</Modal.Body>
+        <Modal.Body className={body()}>{courseDesc}</Modal.Body>
       </Modal.Content>
     </Modal>
   );


### PR DESCRIPTION
closes #148

## Context

This PR aims to fix the formatting of course's information data (bullets points appear on the same line etc) as described in issue 148

## Changes

+ `whitespace-pre-wrap` css property for course's information modal

## How to Test

1. head to home page
2. search for a particular course (try `Computational Thinking`)
3. click on `see more` for information section
4. check if course information detail is formatted correctly

## Preview / Screenshots
Correctly formatted information detail:
<img width="791" alt="Screenshot 2024-08-04 at 3 58 45 PM" src="https://github.com/user-attachments/assets/eab34ee9-0d4c-4996-a81c-242bb9bf4320">


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [x] _(where applicable)_ I have added tests to cover my changes
- [x] _(where applicable)_ I have updated the documentation accordingly
