### PR TITLE
fix(ui): review label tag on review form not reactive to clicks

### DIFF
--- a/src/common/components/Tag/Tag.tsx
+++ b/src/common/components/Tag/Tag.tsx
@@ -29,14 +29,13 @@ export const Tag = ({
   className,
   ...props
 }: TagProps) => {
-  const [_active, setIsActive] = useState(active);
-  const isActive = active ?? _active;
-
+  const [isActive, setIsActive] = useState(active);
   const { tag, icon: iconTheme } = tagTheme({
     active: isActive,
     clickable,
     size,
   });
+
   const StyledIcon = useCallback(
     ({ icon }: { icon: ReactNode }) => {
       if (isValidElement(icon)) {

--- a/src/modules/submit/Combobox/Combobox.theme.ts
+++ b/src/modules/submit/Combobox/Combobox.theme.ts
@@ -5,7 +5,7 @@ export type ComboboxVariants = VariantProps<typeof comboboxTheme>;
 export const comboboxTheme = tv(
   {
     base: [
-      "h-10",
+      "min-h-12",
       "w-full",
       "max-w-sm",
       "items-center",


### PR DESCRIPTION
closes #189 

## Context

<!--- Describe the reason for this change -->
The reason why the tag is not reactive is due to `isActive` not having proper reference to the state as variables are not passed by reference

Updating the values to match fixes the problem

## Changes

<!--- Describe your changes -->
- update tag component `isActive` state variable
- (unrelated) update combobox select height to be `min-h-12` instead of a fixed `h-12`

## How to Test

<!--- Describe how to test your changes -->
1. go to `/submit`
2. select any course
3. click on review label tags
4. see it is now working

## Preview / Screenshots

![screenshot_20240807_005052](https://github.com/user-attachments/assets/171e02dd-8459-4d74-be59-7eb72b1d60ed)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes

