### PR TITLE
fix: course specific review not showing if where in clause is empty array

### DIFF
--- a/src/server/api/routers/reviews.ts
+++ b/src/server/api/routers/reviews.ts
@@ -323,7 +323,7 @@ export const reviewsRouter = createTRPCRouter({
         take: DEFAULT_PAGE_SIZE,
         where: {
           reviewedCourse: { code: input.code },
-          reviewedProfessor: { slug: { in: input.slugs } },
+          reviewedProfessor: input.slugs && { slug: { in: input.slugs } },
         },
         orderBy: input.latest ? { createdAt: "desc" } : undefined,
         select: PRIVATE_REVIEW_FIELDS,


### PR DESCRIPTION
closes #ISSUE_NUMBER

## Context
By default, when loading to course page, we want to see all reviews related to that course in the review section, including reviews that are made for that course only, without being tied to a professor.

When we filter reviews for a particular prof on the course page, we want t othen see all reviews for that prof under this course.

A previous commit https://github.com/AfterClass-io/afterclass.io-v2/pull/193/commits/44bbc526cfa87b0a08d9a27f36986fe8c448668d at #193 broke this `see all reviews related to that course in the review section, including reviews that are made for that course only` behavior unintentionally.

## Preview / Screenshots
Using the same data, without any change to the database, here is the before and after

(The newly added review with the `SELECT ...` text is a course-only review
<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->
### Before
![screenshot_20240807_013120](https://github.com/user-attachments/assets/c74632d5-4804-4b60-bfd2-1fefb85f1542)
![screenshot_20240807_013154](https://github.com/user-attachments/assets/b30c8265-7b70-49b2-b3e8-4713f0b6c006)


### After
![image](https://github.com/user-attachments/assets/4fc201df-7bc1-4348-99bd-ab06533bc957)
![screenshot_20240807_013214](https://github.com/user-attachments/assets/121ce104-e6d2-4b93-b957-639398ceac26)


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
