### PR TITLE
fix(ui): mobile view not scrollable

### DIFF
--- a/src/common/components/CoreLayout/CoreLayout.tsx
+++ b/src/common/components/CoreLayout/CoreLayout.tsx
@@ -8,7 +8,7 @@ export const CoreLayout = ({ children }: CoreLayoutProps) => {
   return (
     <div className="relative flex h-full flex-col">
       <MobileHeader className="flex-shrink-0 sm:hidden" />
-      <div className="relative flex h-full flex-col overflow-hidden sm:flex-row">
+      <div className="relative flex h-full flex-col overflow-hidden overflow-y-auto sm:flex-row">
         <aside className="relative hidden shrink-0 overflow-y-auto border-r border-border-default bg-surface-base sm:block">
           <Sidebar />
         </aside>


### PR DESCRIPTION
## Context

<!--- Describe the reason for this change -->
Currently, the moblie view is not scrollable. This PR fixes this bug

## Changes

- add `overflow-y-scroll` on div below mobile header on CoreLayout

## How to Test

<!--- Describe how to test your changes -->

1. go to `/` 
2. open devtools
3. toggle on mobile view
4. try to scroll, should be able to scroll
5. toggle off mobile view
6. confirm desktop view is working well still

## Preview / Screenshots

### Before

![screenshot_20240812_200052](https://github.com/user-attachments/assets/ea4c879b-5ba3-43fb-baf5-d6240fa9ba2d)


### After

![screenshot_20240812_200002](https://github.com/user-attachments/assets/e6bcc748-c286-483f-a7d6-3f836f630a66)


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
