### PR TITLE
feat: mobile view for rating section

### DIFF
--- a/src/common/components/RatingSection/RatingSection.theme.ts
+++ b/src/common/components/RatingSection/RatingSection.theme.ts
@@ -29,7 +29,6 @@ export const ratingSectionTheme = tv(
         "items-start",
         "rounded-none",
         "w-full",
-        "gap-14",
         "py-0",
         "px-1",
         "capitalize",
@@ -38,8 +37,8 @@ export const ratingSectionTheme = tv(
     },
     variants: {
       size: {
-        md: {},
-        sm: {},
+        md: { statItemWrapper: ["gap-14", "justify-start"] },
+        sm: { statItemWrapper: ["flex-wrap", "gap-5", "justify-between"] },
       },
     },
   },

--- a/src/common/components/RatingSection/RatingSection.tsx
+++ b/src/common/components/RatingSection/RatingSection.tsx
@@ -18,7 +18,9 @@ export const RatingSection = ({
   isLocked,
 }: RatingSectionProps) => {
   const { wrapper, headingContainer, headingRating, statItemWrapper, icon } =
-    ratingSectionTheme();
+    ratingSectionTheme({
+      size: { initial: "sm", md: "md" },
+    });
   return (
     <div className={wrapper()}>
       {isLocked && <LockCtaOverlay />}

--- a/src/common/components/StatItem/StatItem.theme.ts
+++ b/src/common/components/StatItem/StatItem.theme.ts
@@ -12,16 +12,19 @@ export const statItemTheme = tv(
         "gap-2",
         "rounded-none",
       ],
-      label: ["text-text-em-low", "text-center", "font-medium", "text-start"],
-      rating: ["text-text-em-high", "text-center", "font-semibold"],
+      label: [
+        "text-text-em-low",
+        "text-center",
+        "text-sm",
+        "font-medium",
+        "text-start",
+      ],
+      rating: ["text-text-em-high", "text-center", "text-xl", "font-semibold"],
       icon: ["h-7", "w-7"],
     },
     variants: {
       size: {
-        md: {
-          label: ["text-sm"],
-          rating: ["text-xl"],
-        },
+        md: {},
         sm: {
           label: ["text-xs"],
           rating: ["text-md"],

--- a/src/common/components/StatItem/StatItem.theme.ts
+++ b/src/common/components/StatItem/StatItem.theme.ts
@@ -12,14 +12,20 @@ export const statItemTheme = tv(
         "gap-2",
         "rounded-none",
       ],
-      label: ["text-text-em-low", "text-center", "text-sm", "font-medium"],
-      rating: ["text-text-em-high", "text-center", "text-xl", "font-semibold"],
+      label: ["text-text-em-low", "text-center", "font-medium", "text-start"],
+      rating: ["text-text-em-high", "text-center", "font-semibold"],
       icon: ["h-7", "w-7"],
     },
     variants: {
       size: {
-        md: {},
-        sm: {},
+        md: {
+          label: ["text-sm"],
+          rating: ["text-xl"],
+        },
+        sm: {
+          label: ["text-xs"],
+          rating: ["text-md"],
+        },
       },
       layout: {
         horizontal: {

--- a/src/common/components/StatItem/StatItem.tsx
+++ b/src/common/components/StatItem/StatItem.tsx
@@ -19,7 +19,7 @@ export const StatItem = ({
     label: labelClasses,
     rating: ratingClasses,
     icon,
-  } = statItemTheme({ layout });
+  } = statItemTheme({ layout, size: { initial: "sm", md: "md" } });
 
   return (
     <div className={wrapper()}>


### PR DESCRIPTION
closes #203

## Context

This PR focuses on the mobile responsiveness for rating section for both course and prof page (following AC's figma design)

## Changes

+ mobile view for stat item
+ mobile view for rating section as a whole
+ fix desktop view for label alignment by adding `text-start`

## How to Test

1. go to any course / prof review page
2. open devtools
3. toggle on mobile view
4. try to scroll, should be able to scroll
5. toggle off mobile view
6. confirm desktop view is working well still

## Preview / Screenshots

`md` view
![photo_2024-08-22 23 05 50](https://github.com/user-attachments/assets/8dbcba25-4ab8-40f2-a233-f8a6713aa80d)

`sm` view
![photo_2024-08-22 23 06 30](https://github.com/user-attachments/assets/654d5ef7-9f74-4058-ad24-a2e205894753)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
