### PR TITLE
fix: mobile view login button

### DIFF
--- a/src/common/components/CoreLayout/CoreLayout.tsx
+++ b/src/common/components/CoreLayout/CoreLayout.tsx
@@ -1,13 +1,18 @@
 import { type PropsWithChildren } from "react";
 import { Sidebar } from "../Sidebar";
 import { MobileHeader } from "@/common/components/MobileHeader";
+import { getServerAuthSession } from "@/server/auth";
 
 interface CoreLayoutProps extends PropsWithChildren {}
 
-export const CoreLayout = ({ children }: CoreLayoutProps) => {
+export async function CoreLayout({ children }: CoreLayoutProps) {
+  const session = await getServerAuthSession();
   return (
     <div className="flex h-dvh flex-col">
-      <MobileHeader className="flex-shrink-0 sm:hidden" />
+      <MobileHeader
+        className="flex-shrink-0 sm:hidden"
+        isLoggedIn={!!session}
+      />
       <div className="flex flex-1 overflow-hidden">
         <aside className="relative hidden shrink-0 overflow-y-auto border-r border-border-default bg-surface-base sm:block">
           <Sidebar />
@@ -18,4 +23,4 @@ export const CoreLayout = ({ children }: CoreLayoutProps) => {
       </div>
     </div>
   );
-};
+}

--- a/src/common/components/MobileHeader/MobileHeader.tsx
+++ b/src/common/components/MobileHeader/MobileHeader.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { Button } from "@/common/components/Button";
-import { AfterclassIcon } from "@/common/components/CustomIcon";
+import { AfterclassIcon, PlusIcon } from "@/common/components/CustomIcon";
 import { Sidebar } from "@/common/components/Sidebar";
 import { cn } from "@/common/functions";
 import { Icon } from "@iconify-icon/react";
 import Link from "next/link";
 import { useState, type ComponentPropsWithoutRef } from "react";
 
-export interface MobileHeaderProps extends ComponentPropsWithoutRef<"header"> {}
+export interface MobileHeaderProps extends ComponentPropsWithoutRef<"header"> {
+  isLoggedIn: boolean;
+}
 
-export const MobileHeader = ({ ...props }: MobileHeaderProps) => {
+export const MobileHeader = ({ isLoggedIn, ...props }: MobileHeaderProps) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   return (
     <>
@@ -45,15 +47,26 @@ export const MobileHeader = ({ ...props }: MobileHeaderProps) => {
             />
           </button>
 
-          {/* TODO: Add logged in state */}
-          <Button
-            variant="secondary"
-            size="sm"
-            as="a"
-            href="/account/auth/login"
-          >
-            Login
-          </Button>
+          {isLoggedIn ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              as="a"
+              href="/submit"
+              iconLeft={<PlusIcon />}
+            >
+              Write a review
+            </Button>
+          ) : (
+            <Button
+              variant="secondary"
+              size="sm"
+              as="a"
+              href="/account/auth/login"
+            >
+              Login
+            </Button>
+          )}
         </div>
       </header>
 


### PR DESCRIPTION
closes #218

## Context

<!--- Describe the reason for this change -->
changed to reflect the login status of the page for mobile view, replacing the login button in the header with a write a review button

## Changes

<!--- Describe your changes -->

1. removed login button on header
2. added a write a review button that links the user to the write review page

## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->

- changed CoreLayout.tsx to be async
- passed in logged in status as a prop to the MobileHeader component
- renders login or write a review button inside the MobileHeader accordingly

## How to Test

<!--- Describe how to test your changes -->

1. on mobile view, view the page without logging in, a "Login" button should be seen in the header
2. login and the button should be changed into a "Write a review" button


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
