### PR TITLE
feat: mobile view for review submission

### DIFF
--- a/src/app/(school)/submit/page.tsx
+++ b/src/app/(school)/submit/page.tsx
@@ -17,7 +17,7 @@ export default async function SubmitReviewPage() {
   ]);
 
   return (
-    <div className="flex w-full flex-col gap-8">
+    <div className="flex w-full flex-col gap-5 md:gap-8">
       <PageTitle contentRight={<SchoolTag school={school} />}>
         Write a Review
       </PageTitle>

--- a/src/common/components/Label/Label.theme.ts
+++ b/src/common/components/Label/Label.theme.ts
@@ -10,6 +10,7 @@ export const labelTheme = tv(
         "outline-none",
         "placeholder:text-text-em-low",
         "flex-1",
+        "text-sm",
       ],
       wrapper: ["flex", "items-center", "gap-1.5", "pl-1"],
       icon: [],
@@ -17,11 +18,9 @@ export const labelTheme = tv(
     variants: {
       size: {
         md: {
-          label: ["text-sm"],
           icon: ["h-4", "w-4"],
         },
         sm: {
-          label: ["text-xs"],
           icon: ["h-3.5", "w-3.5"],
         },
       },

--- a/src/common/components/PageTitle/PageTitle.theme.ts
+++ b/src/common/components/PageTitle/PageTitle.theme.ts
@@ -1,10 +1,19 @@
 import { tv, type VariantProps } from "tailwind-variants";
 
-export const pageTitleTheme = tv({
-  slots: {
-    wrapper: ["inline-flex", "pb-2", "items-center", "gap-6"],
-    heading: ["text-center", "text-3xl"],
+export const pageTitleTheme = tv(
+  {
+    slots: {
+      wrapper: ["inline-flex", "pb-2", "items-center"],
+      heading: ["text-center"],
+    },
+    variants: {
+      size: {
+        md: { wrapper: ["gap-6"], heading: ["text-3xl"] },
+        sm: { wrapper: ["gap-3"], heading: ["text-lg"] },
+      },
+    },
   },
-});
+  { responsiveVariants: true },
+);
 
 export type PageTitleVariants = VariantProps<typeof pageTitleTheme>;

--- a/src/common/components/PageTitle/PageTitle.tsx
+++ b/src/common/components/PageTitle/PageTitle.tsx
@@ -17,7 +17,9 @@ export const PageTitle = ({
   className,
   ...props
 }: PageTitleProps) => {
-  const { wrapper, heading } = pageTitleTheme();
+  const { wrapper, heading } = pageTitleTheme({
+    size: { initial: "sm", md: "md" },
+  });
   return (
     <div
       {...wrapperProps}

--- a/src/common/components/SchoolTag/SchoolTag.theme.ts
+++ b/src/common/components/SchoolTag/SchoolTag.theme.ts
@@ -1,10 +1,20 @@
 import { tv, type VariantProps } from "tailwind-variants";
 
-export const schoolTagTheme = tv({
-  slots: {
-    heading: ["text-sm"],
-    tagIcon: ["h-6", "w-6"],
+export const schoolTagTheme = tv(
+  {
+    slots: {
+      wrapper: ["py-1"],
+      heading: [],
+      tagIcon: [],
+    },
+    variants: {
+      size: {
+        md: { wrapper: ["pl-[0.38rem]", "pr-3"], heading: ["text-sm"] },
+        sm: { wrapper: ["pl-1", "pr-2"], heading: ["text-xs"] },
+      },
+    },
   },
-});
+  { responsiveVariants: true },
+);
 
 export type SchoolTagVariants = VariantProps<typeof schoolTagTheme>;

--- a/src/common/components/SchoolTag/SchoolTag.tsx
+++ b/src/common/components/SchoolTag/SchoolTag.tsx
@@ -11,9 +11,14 @@ export const SchoolTag = ({
 }: {
   school: SchoolIconProps["school"];
 }) => {
-  const { tagIcon, heading } = schoolTagTheme();
+  const { wrapper, tagIcon, heading } = schoolTagTheme({
+    size: { initial: "sm", md: "md" },
+  });
   return (
-    <Tag contentLeft={<SchoolIcon className={tagIcon()} school={school} />}>
+    <Tag
+      contentLeft={<SchoolIcon className={tagIcon()} school={school} />}
+      className={wrapper()}
+    >
       <Heading as="h5" className={heading()}>
         {school}
       </Heading>

--- a/src/common/components/TagGroup/TagGroup.theme.ts
+++ b/src/common/components/TagGroup/TagGroup.theme.ts
@@ -12,6 +12,7 @@ export const tagGroupTheme = tv(
         "items-start",
         "gap-3",
         "self-stretch",
+        "text-sm",
       ],
       input: ["hidden"],
       tag: ["select-none"],

--- a/src/modules/submit/ReviewForm/ReviewForm.theme.ts
+++ b/src/modules/submit/ReviewForm/ReviewForm.theme.ts
@@ -5,10 +5,10 @@ export type ReviewFormVariants = VariantProps<typeof reviewFormTheme>;
 export const reviewFormTheme = tv(
   {
     slots: {
-      form: ["inline-flex", "flex-col", "items-start", "gap-[3.125rem]"],
+      form: ["inline-flex", "flex-col", "items-start"],
       wrapper: [
         "flex",
-        "w-[48rem]",
+        "max-w-[48rem]",
         "flex-col",
         "items-start",
         "gap-6",
@@ -16,12 +16,27 @@ export const reviewFormTheme = tv(
         "bg-surface-base",
         "px-6",
         "py-8",
+        "w-full",
       ],
-      header: ["flex", "items-end", "justify-between", "self-stretch"],
+      header: ["flex", "justify-between", "self-stretch"],
+      button: ["text-sm"],
       divider: ["h-0", "w-full", "border-border-default"],
       lower: ["flex", "flex-col", "items-start", "gap-8", "self-stretch"],
       textarea: ["w-full"],
     },
+    variants: {
+      size: {
+        md: {
+          form: ["gap-[3.125rem]"],
+          header: ["flex-row", "items-end"],
+        },
+        sm: {
+          form: ["gap-5"],
+          header: ["flex-col", "items-start", "gap-6"],
+        },
+      },
+    },
   },
+
   { responsiveVariants: true },
 );

--- a/src/modules/submit/ReviewForm/ReviewForm.tsx
+++ b/src/modules/submit/ReviewForm/ReviewForm.tsx
@@ -75,7 +75,9 @@ export const ReviewForm = ({ children }: { children: ReactNode }) => {
     });
   };
 
-  const { form: formTheme } = reviewFormTheme();
+  const { form: formTheme } = reviewFormTheme({
+    size: { initial: "sm", md: "md" },
+  });
 
   return (
     <FormProvider {...formMethods}>

--- a/src/modules/submit/ReviewForm/ReviewFormSection.tsx
+++ b/src/modules/submit/ReviewForm/ReviewFormSection.tsx
@@ -36,7 +36,11 @@ export const ReviewFormSection = ({
     watch,
     formState: { errors },
   } = useFormContext<ReviewFormInputsSchema>();
-  const { wrapper, header, divider, lower, textarea } = reviewFormTheme();
+  const { wrapper, header, button, divider, lower, textarea } = reviewFormTheme(
+    {
+      size: { initial: "sm", md: "md" },
+    },
+  );
   const [isSkipped, setIsSkipped] = useState(false);
 
   // type cast required as `watch()` returns never
@@ -71,6 +75,7 @@ export const ReviewFormSection = ({
             <Button
               variant="secondary"
               type="button"
+              className={button()}
               onClick={() => {
                 setIsSkipped(false);
                 setValue("type", ReviewableEnum.PROFESSOR);
@@ -83,6 +88,7 @@ export const ReviewFormSection = ({
             <Button
               variant="tertiary"
               type="button"
+              className={button()}
               onClick={() => {
                 setIsSkipped(true);
                 setValue("type", ReviewableEnum.COURSE);


### PR DESCRIPTION
closes #206

## Context

<!--- Describe the reason for this change -->
This PR implements the responsiveness for mobile view for the review submission page (according to the figma)

## Changes

<!--- Describe your changes -->
implemented responsiveness for the following components according to figma:
1. PageTitle component (this changes every page that uses the PageTitle component)
2. SchoolTag
3. ReviewForm

edited these components:

1. Label: constant font size (according to the figma, its 14px)
2. TagGroup: font size 14px as well

## How to Test

<!--- Describe how to test your changes -->

1. visit "/submit" endpoint on the afterclass page
2. either slowly resize the page or open your browser's devtools and toggle between phone dimensions/normal view

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->
Mobile View (Figma): 
![image](https://github.com/user-attachments/assets/f6d4c2b8-ffd5-426b-afcc-001472d9726b)
![image](https://github.com/user-attachments/assets/95c531b3-5f30-41a1-8837-644279429253)


Mobile View (Page):
![image](https://github.com/user-attachments/assets/cfe2c6be-5acb-4e04-ad21-c003ab5aa3b0)
![image](https://github.com/user-attachments/assets/b0dedb6d-0583-4012-ba60-fd7c95530ae3)
![image](https://github.com/user-attachments/assets/109cdf49-09d4-4103-a56c-b0d8ccaeb060)



Web View (Figma):
![image](https://github.com/user-attachments/assets/98e5c278-7abc-4757-becc-71151819997d)
![image](https://github.com/user-attachments/assets/21fb4dbb-9c73-4844-8bf7-707bfe164a58)


Web View (Page):
![image](https://github.com/user-attachments/assets/5588e8a8-7704-4a00-b615-86631996bb9f)
![image](https://github.com/user-attachments/assets/33b72ff5-de3a-49af-96d2-40de264b9842)
![image](https://github.com/user-attachments/assets/7526d3bf-d0c2-449f-8777-d7d143af34a0)




## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
