### PR TITLE
feat: mobile add review submission and contribute buttons to the sidebar drawer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,4 @@ NEXT_PUBLIC_SUPPORTED_SCH_DOMAINS="sch1.com,sch2.com"
 # AC Channels' Link
 NEXT_PUBLIC_AC_CHANNEL_LINK=https://t.me/xxxxxx
 NEXT_PUBLIC_AC_HELPDESK_LINK=https://t.me/xxxxxx
+NEXT_PUBLIC_AC_GITHUB_LINK=https://github.com/xxxxxx

--- a/src/app/(school)/(reviews)/layout.tsx
+++ b/src/app/(school)/(reviews)/layout.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 
 import { CtaCard } from "@/common/components/CtaCard";
 import { EditIcon, GithubIcon, PlusIcon } from "@/common/components/CustomIcon";
+import { env } from "@/env.mjs";
 
 export default function ReviewLayout({
   children,
@@ -35,7 +36,7 @@ export default function ReviewLayout({
           <CtaCard
             variant="tertiary"
             ctaText="Contribute to AfterClass OSS"
-            href="https://github.com/AfterClass-io/afterclass.io-v2"
+            href={env.NEXT_PUBLIC_AC_GITHUB_LINK}
             external
             leftIcon={<GithubIcon />}
           />

--- a/src/common/components/Sidebar/Sidebar.tsx
+++ b/src/common/components/Sidebar/Sidebar.tsx
@@ -10,6 +10,8 @@ import {
   StarLineAltIcon,
   TelegramIcon,
   HelpDeskIcon,
+  PlusIcon,
+  GithubIcon,
 } from "@/common/components/CustomIcon";
 import { SidebarItem } from "@/common/components/SidebarItem";
 import { Logo } from "@/common/components/Logo";
@@ -30,6 +32,18 @@ const SIDEBAR_ITEMS = [
     icon: <ChartLineIcon />,
     href: "/bidding",
     category: "feature",
+  },
+  {
+    label: "Write a Review",
+    icon: <PlusIcon size={16} />,
+    href: "/submit",
+    category: "contribute",
+  },
+  {
+    label: "AfterClass OSS",
+    icon: <GithubIcon size={16} />,
+    href: "https://github.com/AfterClass-io/afterclass.io-v2",
+    category: "contribute",
   },
   {
     label: "Channel",
@@ -66,6 +80,9 @@ export const Sidebar = ({
   const SIDEBAR_CHANNELS_ITEMS = SIDEBAR_ITEMS.filter(
     (item) => item.category === "channel",
   );
+  const SIDEBAR_CONTRIBUTE_ITEMS = SIDEBAR_ITEMS.filter(
+    (item) => item.category === "contribute",
+  );
   return (
     <div
       {...props}
@@ -97,7 +114,27 @@ export const Sidebar = ({
         decorative
         orientation="horizontal"
       />
+      {/* Contribute section, only visible on mobile */}
+      <div className="block md:hidden">
+        <div className="px-3 py-2 text-xs text-text-em-low">Contribute</div>
+        <ul className="space-y-2">
+          {SIDEBAR_CONTRIBUTE_ITEMS.map((item) => (
+            <SidebarItem
+              key={item.href}
+              {...item}
+              active={pathname === item.href}
+              external={item.href.startsWith("http") ? true : false}
+            />
+          ))}
+        </ul>
+      </div>
+      <Separator.Root
+        className="block h-px w-full bg-border-default md:hidden"
+        decorative
+        orientation="horizontal"
+      />
       <div>
+        <div className="px-3 py-2 text-xs text-text-em-low">Telegram</div>
         <ul className="space-y-2">
           {SIDEBAR_CHANNELS_ITEMS.map((item) => (
             <SidebarItem key={item.href} {...item} external={true} />

--- a/src/common/components/Sidebar/Sidebar.tsx
+++ b/src/common/components/Sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ const SIDEBAR_ITEMS = [
   {
     label: "AfterClass OSS",
     icon: <GithubIcon size={16} />,
-    href: "https://github.com/AfterClass-io/afterclass.io-v2",
+    href: env.NEXT_PUBLIC_AC_GITHUB_LINK,
     category: "contribute",
   },
   {

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -73,6 +73,7 @@ export const env = createEnv({
       ),
     NEXT_PUBLIC_AC_CHANNEL_LINK: z.string().url(),
     NEXT_PUBLIC_AC_HELPDESK_LINK: z.string().url(),
+    NEXT_PUBLIC_AC_GITHUB_LINK: z.string().url(),
   },
 
   /**
@@ -94,6 +95,7 @@ export const env = createEnv({
       process.env.NEXT_PUBLIC_SUPPORTED_SCH_DOMAINS,
     NEXT_PUBLIC_AC_CHANNEL_LINK: process.env.NEXT_PUBLIC_AC_CHANNEL_LINK,
     NEXT_PUBLIC_AC_HELPDESK_LINK: process.env.NEXT_PUBLIC_AC_HELPDESK_LINK,
+    NEXT_PUBLIC_AC_GITHUB_LINK: process.env.NEXT_PUBLIC_AC_GITHUB_LINK,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.


### PR DESCRIPTION
closes #219 

## Context

This PR focuses on adding review submission and contribute buttons to the sidebar drawer on mobile view. These 2 items will not be visible on sidebar for any non-mobile view.

## Changes

+ AC GitHub Link as env variable
+ New side menu items (Write a Review + AfterClass OSS)
+ New UI/UX for sidebar menu (added title for each section)
+ Change `href` on cta card on desktop view from actual link to env

## How to Test

1. go to AC's homepage at `/`
2. open devtools
3. toggle on mobile view
4. Side menu items for Write a Review + AfterClass OSS should be observed
5. Exit mobile view
6. Side menu items for Write a Review + AfterClass OSS should NOT be observed

## Preview / Screenshots

`mobile`

<img width="534" alt="Screenshot 2024-08-29 at 11 56 16 PM" src="https://github.com/user-attachments/assets/f123ccbf-270d-49f8-9c87-63e0278f3f08">


`desktop`

<img width="1498" alt="Screenshot 2024-08-29 at 11 54 58 PM" src="https://github.com/user-attachments/assets/5b969086-4982-402d-ab79-56e90a0718d8">


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
