### PR TITLE
feat(ui): disallow mobile to zoom on form input

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,7 @@ export const viewport: Viewport = {
   ],
   width: "device-width",
   initialScale: 1.0,
+  maximumScale: 1.0,
 };
 
 export const metadata: Metadata = {


### PR DESCRIPTION
closes #220 

## Context

<!--- Describe the reason for this change -->
currently, when user clicks on form input, the browser scales the viewport for the user on focus. this is an unintended and potentially annoying feature.

this pr disables that autozoom


## Changes

- add `maximum-scale=1` to viewport meta

## Implementation Details

see https://stackoverflow.com/a/46254706

## How to Test

<!--- Describe how to test your changes -->
1. click on preview link on mobile
2. click login
3. click email / password field
4. should not see zooming

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
