### PR TITLE
feat(auth): redirect to acct creation on v1 acct pwd reset

### DIFF
--- a/src/app/account/auth/forgot/page.tsx
+++ b/src/app/account/auth/forgot/page.tsx
@@ -1,9 +1,9 @@
-import { AuthCard, ForgotPasswordForm } from "@/modules/auth/components";
+import { AuthCard, ForgotPwdForm } from "@/modules/auth/components";
 
 export default function ForgotPassword() {
   return (
     <AuthCard title="Forgot your password?">
-      <ForgotPasswordForm />
+      <ForgotPwdForm />
     </AuthCard>
   );
 }

--- a/src/app/account/auth/signup/page.tsx
+++ b/src/app/account/auth/signup/page.tsx
@@ -10,15 +10,14 @@ export default function SignUp({
 }: {
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const { success: isValidEmail } = emailValidationSchema.safeParse(
-    searchParams.email,
-  );
+  const { success: isValidEmail, data: v1Email } =
+    emailValidationSchema.safeParse(searchParams.email);
 
   return (
     <>
       {isValidEmail && <SignupModalV1User />}
       <AuthCard title="Create an account">
-        <SignupForm />
+        <SignupForm defaultEmail={v1Email} />
       </AuthCard>
     </>
   );

--- a/src/app/account/auth/signup/page.tsx
+++ b/src/app/account/auth/signup/page.tsx
@@ -1,9 +1,22 @@
-import { AuthCard, SignupForm } from "@/modules/auth/components";
+import {
+  AuthCard,
+  SignupForm,
+  SignupModalV1User,
+} from "@/modules/auth/components";
 
-export default function SignUp() {
+export default function SignUp({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const existingV1UserEmail = searchParams.email;
+
   return (
-    <AuthCard title="Create an account">
-      <SignupForm />
-    </AuthCard>
+    <>
+      {existingV1UserEmail && <SignupModalV1User />}
+      <AuthCard title="Create an account">
+        <SignupForm />
+      </AuthCard>
+    </>
   );
 }

--- a/src/app/account/auth/signup/page.tsx
+++ b/src/app/account/auth/signup/page.tsx
@@ -1,3 +1,4 @@
+import { emailValidationSchema } from "@/common/tools/zod/schemas";
 import {
   AuthCard,
   SignupForm,
@@ -9,11 +10,13 @@ export default function SignUp({
 }: {
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const existingV1UserEmail = searchParams.email;
+  const { success: isValidEmail } = emailValidationSchema.safeParse(
+    searchParams.email,
+  );
 
   return (
     <>
-      {existingV1UserEmail && <SignupModalV1User />}
+      {isValidEmail && <SignupModalV1User />}
       <AuthCard title="Create an account">
         <SignupForm />
       </AuthCard>

--- a/src/modules/auth/components/ForgotPwdForm.tsx
+++ b/src/modules/auth/components/ForgotPwdForm.tsx
@@ -1,16 +1,17 @@
 "use client";
-import { useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { useForm, type SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
-import { env } from "@/env";
 import { supabase } from "@/server/supabase";
+
 import { Input } from "@/common/components/Input";
 import { Button } from "@/common/components/Button";
+import { env } from "@/env";
 import { EnvelopeIcon } from "@/common/components/CustomIcon";
 
 import { isUserExistsAndNotV1ElseRedirectToSignup } from "../functions";
 import { type ForgotPwdFormInputs, forgotPwdFormInputsSchema } from "../types";
-import { useRouter } from "next/navigation";
 
 export const ForgotPwdForm = () => {
   const router = useRouter();
@@ -25,7 +26,7 @@ export const ForgotPwdForm = () => {
     mode: "onTouched",
   });
 
-  const onSubmit = async ({ email }: ForgotPwdFormInputs) => {
+  const onSubmit: SubmitHandler<ForgotPwdFormInputs> = async ({ email }) => {
     if (isSubmitting) return;
 
     const errMsg = await isUserExistsAndNotV1ElseRedirectToSignup({ email });

--- a/src/modules/auth/components/ForgotPwdForm.tsx
+++ b/src/modules/auth/components/ForgotPwdForm.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { startTransition } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -24,14 +23,10 @@ export const ForgotPwdForm = () => {
   return (
     <form
       className="flex w-full flex-col gap-6"
-      onSubmit={handleSubmit((data) => {
-        startTransition(async () => {
-          const err = await forgotPasswordFormAction(data);
-          if (err) {
-            alert(err.message);
-            reset();
-          }
-        });
+      onSubmit={handleSubmit(async (data) => {
+        const errMsg = await forgotPasswordFormAction(data);
+        if (errMsg) alert(errMsg);
+        reset();
       })}
     >
       <Input

--- a/src/modules/auth/components/SignupForm.tsx
+++ b/src/modules/auth/components/SignupForm.tsx
@@ -34,10 +34,11 @@ const signupFormInputsSchema = z
   });
 type SignupFormInputs = z.infer<typeof signupFormInputsSchema>;
 
-export const SignupForm = () => {
+export const SignupForm = ({ defaultEmail }: { defaultEmail?: string }) => {
   const router = useRouter();
   const [isPwdVisible, setIsPwdVisible] = useState(false);
   const [isCfmPwdVisible, setIsCfmPwdVisible] = useState(false);
+
   const {
     register,
     handleSubmit,
@@ -46,7 +47,9 @@ export const SignupForm = () => {
   } = useForm<SignupFormInputs>({
     resolver: zodResolver(signupFormInputsSchema),
     mode: "onTouched",
+    defaultValues: { email: defaultEmail },
   });
+
   const onSubmit: SubmitHandler<SignupFormInputs> = async (data) => {
     if (isSubmitting) return;
     try {

--- a/src/modules/auth/components/SignupModalV1User.tsx
+++ b/src/modules/auth/components/SignupModalV1User.tsx
@@ -2,71 +2,58 @@
 import { Button } from "@/common/components/Button";
 import { Modal } from "@/common/components/Modal";
 import { env } from "@/env";
-import { useState } from "react";
 
-export const SignupModalV1User = () => {
-  const [open, setOpen] = useState(!localStorage.getItem("isV1User"));
-
-  return (
-    <Modal
-      open={open}
-      onOpenChange={(open) => {
-        if (!open) {
-        }
-      }}
+export const SignupModalV1User = () => (
+  <Modal defaultOpen>
+    <Modal.Content
+      onOpenAutoFocus={(e) => e.preventDefault()}
+      data-test="v1-signup-modal"
     >
-      <Modal.Content onOpenAutoFocus={(e) => e.preventDefault()}>
-        <Modal.Header>⚠️ Important Notice ⚠️</Modal.Header>
-        <Modal.Body>
-          <div className="space-y-2 text-xs md:space-y-4 md:text-base">
-            <div className="flex flex-col items-start md:flex-row md:items-center">
-              <span className="mr-1">
-                It looks like you are trying to reset your password for the
-              </span>
-              <Button
-                as="a"
-                variant="link"
-                className="inline-flex h-fit p-0 pb-[1px] text-text-em-high underline hover:text-secondary-default md:h-fit md:p-0"
-                href={env.NEXT_PUBLIC_OLD_SITE_URL}
-                external
-                isResponsive
-              >
-                old AfterClass website.
-              </Button>
-            </div>
-            <p>
-              As we migrate to a new platform, users from the old AfterClass
-              website can still
-              <b className="ml-1 text-text-em-high">
-                access the new AfterClass platform using the same email and
-                password.
-              </b>
-            </p>
-            <p>
-              {/* <b className="mr-1 text-text-em-high">NOTE:</b> */}
-              Password resets will not work for accounts created on the old
-              AfterClass website on the new AfterClass platform.
-            </p>
-            <p>
-              <b className="ml-r text-text-em-high">Forgot your password?</b> No
-              worries! Just create a new account using the same email.
-            </p>
+      <Modal.Header>⚠️ Important Notice ⚠️</Modal.Header>
+      <Modal.Body>
+        <div className="space-y-2 text-xs md:space-y-4 md:text-base">
+          <div className="flex flex-col items-start md:flex-row md:items-center">
+            <span className="mr-1">
+              It looks like you are trying to reset your password for the
+            </span>
+            <Button
+              as="a"
+              variant="link"
+              className="inline-flex h-fit p-0 pb-[1px] text-text-em-high underline hover:text-secondary-default md:h-fit md:p-0"
+              href={env.NEXT_PUBLIC_OLD_SITE_URL}
+              external
+              isResponsive
+            >
+              old AfterClass website.
+            </Button>
           </div>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button fullWidth onClick={() => setOpen(false)}>
-            Create a new account
-          </Button>
-          <Button
-            fullWidth
-            as="a"
-            variant="tertiary"
-            href="/account/auth/login"
-          >
-            Login with old AfterClass account
-          </Button>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal>
-  );
-};
+          <p>
+            As we migrate to a new platform, users from the old AfterClass
+            website can still
+            <b className="ml-1 text-text-em-high">
+              access the new AfterClass platform using the same email and
+              password.
+            </b>
+          </p>
+          <p>
+            {/* <b className="mr-1 text-text-em-high">NOTE:</b> */}
+            Password resets will not work for accounts created on the old
+            AfterClass website on the new AfterClass platform.
+          </p>
+          <p>
+            <b className="ml-r text-text-em-high">Forgot your password?</b> No
+            worries! Just create a new account using the same email.
+          </p>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Modal.Close asChild>
+          <Button fullWidth>Create a new account</Button>
+        </Modal.Close>
+        <Button fullWidth as="a" variant="tertiary" href="/account/auth/login">
+          Login with old AfterClass account
+        </Button>
+      </Modal.Footer>
+    </Modal.Content>
+  </Modal>
+);

--- a/src/modules/auth/components/SignupModalV1User.tsx
+++ b/src/modules/auth/components/SignupModalV1User.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { Button } from "@/common/components/Button";
+import { Modal } from "@/common/components/Modal";
+import { env } from "@/env";
+import { useState } from "react";
+
+export const SignupModalV1User = () => {
+  const [open, setOpen] = useState(!localStorage.getItem("isV1User"));
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) {
+        }
+      }}
+    >
+      <Modal.Content onOpenAutoFocus={(e) => e.preventDefault()}>
+        <Modal.Header>⚠️ Important Notice ⚠️</Modal.Header>
+        <Modal.Body>
+          <div className="space-y-2 text-xs md:space-y-4 md:text-base">
+            <div className="flex flex-col items-start md:flex-row md:items-center">
+              <span className="mr-1">
+                It looks like you are trying to reset your password for the
+              </span>
+              <Button
+                as="a"
+                variant="link"
+                className="inline-flex h-fit p-0 pb-[1px] text-text-em-high underline hover:text-secondary-default md:h-fit md:p-0"
+                href={env.NEXT_PUBLIC_OLD_SITE_URL}
+                external
+                isResponsive
+              >
+                old AfterClass website.
+              </Button>
+            </div>
+            <p>
+              As we migrate to a new platform, users from the old AfterClass
+              website can still
+              <b className="ml-1 text-text-em-high">
+                access the new AfterClass platform using the same email and
+                password.
+              </b>
+            </p>
+            <p>
+              {/* <b className="mr-1 text-text-em-high">NOTE:</b> */}
+              Password resets will not work for accounts created on the old
+              AfterClass website on the new AfterClass platform.
+            </p>
+            <p>
+              <b className="ml-r text-text-em-high">Forgot your password?</b> No
+              worries! Just create a new account using the same email.
+            </p>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button fullWidth onClick={() => setOpen(false)}>
+            Create a new account
+          </Button>
+          <Button
+            fullWidth
+            as="a"
+            variant="tertiary"
+            href="/account/auth/login"
+          >
+            Login with old AfterClass account
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+};

--- a/src/modules/auth/components/index.ts
+++ b/src/modules/auth/components/index.ts
@@ -3,4 +3,4 @@ export * from "./LoginForm";
 export * from "./SignupForm";
 export * from "./ResetPasswordForm";
 export * from "./ConfirmSignUpNote";
-export * from "./ForgotPasswordForm";
+export * from "./ForgotPwdForm";

--- a/src/modules/auth/components/index.ts
+++ b/src/modules/auth/components/index.ts
@@ -1,6 +1,7 @@
 export * from "./AuthCard";
 export * from "./LoginForm";
 export * from "./SignupForm";
+export * from "./SignupModalV1User";
 export * from "./ResetPasswordForm";
 export * from "./ConfirmSignUpNote";
 export * from "./ForgotPwdForm";

--- a/src/modules/auth/functions/forgotPwdFormAction.ts
+++ b/src/modules/auth/functions/forgotPwdFormAction.ts
@@ -1,12 +1,12 @@
 "use server";
 import { redirect } from "next/navigation";
 
-import { env } from "@/env";
-import { supabase } from "@/server/supabase";
 import { db } from "@/server/db";
-import { ForgotPwdFormInputs } from "../types";
+import { type ForgotPwdFormInputs } from "../types";
 
-export async function forgotPasswordFormAction({ email }: ForgotPwdFormInputs) {
+export async function isUserExistsAndNotV1ElseRedirectToSignup({
+  email,
+}: ForgotPwdFormInputs) {
   const user = await db.users.findUnique({
     where: { email },
   });
@@ -16,13 +16,7 @@ export async function forgotPasswordFormAction({ email }: ForgotPwdFormInputs) {
   }
 
   if (user.deprecatedPasswordDigest) {
+    // only v1 users have deprecatedPasswordDigest
     redirect(`/account/auth/signup?email=${email}`);
   }
-
-  const { error } = await supabase.auth.resetPasswordForEmail(email, {
-    redirectTo: `${env.NEXT_PUBLIC_SITE_URL}/account/auth/reset-password`,
-  });
-  if (error) return error.message;
-
-  redirect(`/account/auth/verify?email=${email}`);
 }

--- a/src/modules/auth/functions/forgotPwdFormAction.ts
+++ b/src/modules/auth/functions/forgotPwdFormAction.ts
@@ -1,0 +1,25 @@
+"use server";
+import { redirect } from "next/navigation";
+
+import { env } from "@/env";
+import { supabase } from "@/server/supabase";
+import { db } from "@/server/db";
+import { ForgotPwdFormInputs } from "../types";
+
+export async function forgotPasswordFormAction(formData: ForgotPwdFormInputs) {
+  const { email } = formData;
+  const user = await db.users.findUnique({
+    where: { email },
+  });
+
+  if (user && user.deprecatedPasswordDigest) {
+    redirect("/account/auth/signup");
+  }
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    redirectTo: `${env.NEXT_PUBLIC_SITE_URL}/account/auth/reset-password`,
+  });
+  if (error) return error;
+
+  redirect(`/account/auth/verify?email=${email}`);
+}

--- a/src/modules/auth/functions/forgotPwdFormAction.ts
+++ b/src/modules/auth/functions/forgotPwdFormAction.ts
@@ -6,20 +6,23 @@ import { supabase } from "@/server/supabase";
 import { db } from "@/server/db";
 import { ForgotPwdFormInputs } from "../types";
 
-export async function forgotPasswordFormAction(formData: ForgotPwdFormInputs) {
-  const { email } = formData;
+export async function forgotPasswordFormAction({ email }: ForgotPwdFormInputs) {
   const user = await db.users.findUnique({
     where: { email },
   });
 
-  if (user && user.deprecatedPasswordDigest) {
-    redirect("/account/auth/signup");
+  if (!user) {
+    return "User not found";
+  }
+
+  if (user.deprecatedPasswordDigest) {
+    redirect(`/account/auth/signup?email=${email}`);
   }
 
   const { error } = await supabase.auth.resetPasswordForEmail(email, {
     redirectTo: `${env.NEXT_PUBLIC_SITE_URL}/account/auth/reset-password`,
   });
-  if (error) return error;
+  if (error) return error.message;
 
   redirect(`/account/auth/verify?email=${email}`);
 }

--- a/src/modules/auth/functions/index.ts
+++ b/src/modules/auth/functions/index.ts
@@ -1,0 +1,1 @@
+export * from "./forgotPwdFormAction";

--- a/src/modules/auth/types/forgotPwdFormTypes.ts
+++ b/src/modules/auth/types/forgotPwdFormTypes.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+import { emailValidationSchema } from "@/common/tools/zod/schemas";
+
+export const forgotPwdFormInputsSchema = z.object({
+  email: emailValidationSchema,
+});
+export type ForgotPwdFormInputs = z.infer<typeof forgotPwdFormInputsSchema>;

--- a/src/modules/auth/types/index.ts
+++ b/src/modules/auth/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./forgotPwdFormTypes";


### PR DESCRIPTION
## Context

<!--- Describe the reason for this change -->
The reason for this change is that many v1 users who have forgotten their password attempted to reset password on v2 site, despite instructions to create an account on v2 instead.

This has led to confusion by the user as resetting password on v2 wont work since user is manageed with supabase auth and v1 users haven't yet exist on supabase auth.

This change will redirect user to sign up page with a Modal explaining that they should create an account instead, when user attempts to reset a password for a v1 account.

## Changes

<!--- Describe your changes -->

- reset password prompt now redirects to signup page if email given is a v1 account

## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->

1. user submits reset request with an email
2. check if email exists. if no: show error message to user that email doesnt exist
3. check if `deprecatedPasswordDigest` column is populated. if no: continue supabase reset flow
4. redirect to signup with email query param
5. show the important notice modal to let user know that they need to create an account
6. prepopulate form with the email for easier submission

## How to Test

<!--- Describe how to test your changes -->
- use `test_hash_pwd@smu.edu.sg` to test for v1 user (reset redirects to signup flow)
- use `test@smu.edu.sg` to test for v2 user (normal supabase flow)

steps:
1. head to `/account/auth/forgot`
2. enter email
3. observe the flow based on type of email


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
