### PR TITLE
feat: local config fallback for invalid edge config

### DIFF
--- a/src/common/providers/EdgeConfig/EdgeConfigProvider.tsx
+++ b/src/common/providers/EdgeConfig/EdgeConfigProvider.tsx
@@ -1,33 +1,44 @@
 import { getAll } from "@vercel/edge-config";
 import { edgeConfigSchema } from "@/server/ecfg/config";
-
 import { EdgeConfigContextProvider } from "./EdgeConfigContextProvider";
+
+async function fetchAndValidateEdgeConfig() {
+  try {
+    const rawConfig = await getAll();
+    const result = edgeConfigSchema.safeParse(rawConfig);
+
+    if (!result.success) {
+      console.warn(
+        "Failed to parse edge config:\n",
+        result.error.message,
+        "\nReceived config:\n",
+        rawConfig,
+      );
+      return null;
+    }
+
+    return result.data;
+  } catch (error) {
+    console.warn(
+      "Failed to fetch edge config:\n",
+      error instanceof Error ? error.message : error,
+    );
+    return null;
+  }
+}
+
+async function getFallbackConfig() {
+  return (await import("@/server/ecfg/config.json")).default;
+}
 
 export async function EdgeConfigProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  // * FUTURE NOTE *
-  // if edge requests count nears the threshold,
-  // we should consider caching the edge config & revalidate every 24h
-  const edgeConfigRaw = await getAll();
-  const validateEcfg = edgeConfigSchema.safeParse(edgeConfigRaw);
-  let edgeConfig;
-  if (validateEcfg.success) {
-    edgeConfig = validateEcfg.data;
-  } else {
-    console.warn(
-      "Failed to parse edge config:\n",
-      validateEcfg.error.message,
-      "\n\n",
-      "Received config:\n",
-      edgeConfigRaw,
-    );
-    // used strictly as a fallback if edge config
-    // somehow returns an unexpected format
-    edgeConfig = (await import("@/server/ecfg/config.json")).default;
-  }
+  const edgeConfig =
+    (await fetchAndValidateEdgeConfig()) ?? (await getFallbackConfig());
+
   return (
     <EdgeConfigContextProvider edgeConfig={edgeConfig}>
       {children}

--- a/src/common/providers/EdgeConfig/EdgeConfigProvider.tsx
+++ b/src/common/providers/EdgeConfig/EdgeConfigProvider.tsx
@@ -4,6 +4,9 @@ import { EdgeConfigContextProvider } from "./EdgeConfigContextProvider";
 
 async function fetchAndValidateEdgeConfig() {
   try {
+    // * FUTURE NOTE *
+    // if edge requests count nears the threshold,
+    // we should consider caching the edge config & revalidate every 24h
     const rawConfig = await getAll();
     const result = edgeConfigSchema.safeParse(rawConfig);
 


### PR DESCRIPTION
closes #ISSUE_NUMBER

## Context

<!--- Describe the reason for this change -->
- add fallback to use local json config if dev doesnt' have the correct edge config env token, so development workflow isn't blocked

## Changes

<!--- Describe your changes -->

## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->

## How to Test

<!--- Describe how to test your changes -->
- app should work locally with /without or correct/incorrect `EDGE_CONFIG` variable in `.env` file
## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
