### PR TITLE
chore: onboard CVE remediation policy

### DIFF
--- a/.cve-remediation.yml
+++ b/.cve-remediation.yml
@@ -1,0 +1,20 @@
+# CVE remediation policy for afterclass.io (fork of afterclass-io/afterclass.io)
+# Compose currently brings up Postgres only; app runs via `bun run start` for smoke.
+
+ecosystems: [npm]
+packageManager: bun
+
+# SKIP_ENV_VALIDATION: t3 env schema requires many secrets; dep remediations don't need them.
+build: "bun install && SKIP_ENV_VALIDATION=1 bun run build"
+test: "bun run lint"
+
+compose:
+  file: docker-compose.yaml
+  up: "docker compose -f docker-compose.yaml up -d --wait"
+  # Postgres-only stack today — gate that DB is healthy (not a Next.js HTTP healthcheck).
+  smoke: "docker compose -f docker-compose.yaml exec -T db pg_isready -U postgres -h localhost"
+
+sast:
+  enabled: true
+  config: p/typescript
+  gate: no-new


### PR DESCRIPTION
## Summary
- Adds `.cve-remediation.yml` so the CVE remediation bot can scan/fix this fork
- Build: `bun install` + `SKIP_ENV_VALIDATION=1 bun run build`
- Test: `bun run lint`
- Compose smoke: Postgres `pg_isready` (compose is DB-only today)

## Test plan
- [ ] Policy parses / bot accepts onboarding
- [ ] Live remediate run against this fork with Codex


Made with [Cursor](https://cursor.com)